### PR TITLE
Update swift to point to OpenStack project entry

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -601,10 +601,10 @@ landscape:
             crunchbase: 'https://www.crunchbase.com/organization/storageos'
           - item:
             name: Swift
-            homepage_url: 'https://www.swiftstack.com/product/openstack-swift'
+            homepage_url: 'https://docs.openstack.org/swift/latest/'
             repo_url: 'https://github.com/openstack/swift'
-            logo: 'http://d.not.mn/OpenStack_Project_Swift_vertical.png'
-            twitter: 'https://twitter.com/swiftstack?lang=en'
+            logo: 'https://www.openstack.org/themes/openstack/images/project-mascots/Swift/OpenStack_Project_Swift_vertical.png'
+            twitter: 'https://twitter.com/OpenStack'
             crunchbase: 'https://www.crunchbase.com/organization/openstack'
       - subcategory:
         name: Container Runtime


### PR DESCRIPTION
Swift is a project that is housed by the OpenStack Foundation, not by
the company SwiftStack. SwiftStack is also a fine group of humans, but
we should use the project links here.