### PR TITLE
Update repo_url for openstack

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -108,7 +108,7 @@ landscape:
           - item:
             name: OpenStack
             homepage_url: 'https://www.openstack.org/'
-            repo_url: 'https://github.com/openstack/nova'
+            repo_url: 'https://github.com/openstack/openstack'
             logo: 'https://upload.wikimedia.org/wikipedia/commons/e/e6/OpenStack%C2%AE_Logo_2016.svg'
             twitter: 'https://twitter.com/OpenStack'
             crunchbase: 'https://www.crunchbase.com/organization/openstack'


### PR DESCRIPTION
OpenStack != nova - nova is only one component. While the
openstack/openstack repo in github isn't really the exact story either,
it's more correct than the openstack/nova repo.