### PR TITLE
Add Codefresh products to appropriate categories

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -210,6 +210,12 @@ landscape:
             twitter: 'https://twitter.com/CloudifySource'
             crunchbase: 'https://www.crunchbase.com/organization/cloudify'
           - item:
+            name: Codefresh
+            homepage_url: 'https://codefresh.io/features/#Helm'
+            logo: 'https://codefresh.io/wp-content/uploads/2018/03/Codefresh-Helm.svg'
+            twitter: 'https://codefresh.io'
+            crunchbase: 'https://www.crunchbase.com/organization/code-fresh'
+          - item:
             name: Helm
             homepage_url: 'https://helm.sh/'
             repo_url: 'https://github.com/kubernetes/helm'
@@ -234,7 +240,7 @@ landscape:
           - item:
             name: Kubicorn
             homepage_url: 'https://github.com/kris-nova/kubicorn'
-            repo_url: 'https://github.com/kubicorn/kubicorn'
+            repo_url: 'https://github.com/kris-nova/kubicorn'
             logo: ./hosted_logos/kubicorn.svg
             twitter: 'https://twitter.com/kubicornk8s'
             crunchbase: 'https://www.crunchbase.com/organization/kubicorn'
@@ -267,6 +273,12 @@ landscape:
             logo: ./hosted_logos/azureregistry.svg
             twitter: 'https://twitter.com/azure'
             crunchbase: 'https://www.crunchbase.com/organization/microsoft'
+          - item:
+            name: Codefresh Registry
+            homepage_url: 'https://codefresh.io/docs/docs/docker-registries/codefresh-registry/'
+            logo: 'https://codefresh.io/wp-content/uploads/2018/03/Codefresh-Registry.svg'
+            twitter: 'https://codefresh.io'
+            crunchbase: 'https://www.crunchbase.com/organization/code-fresh'
           - item:
             name: Docker Registry
             homepage_url: 'https://docs.docker.com/registry/'


### PR DESCRIPTION
The Codefresh registry launched less than 6 months ago and already stores 3-4 million images and is used by thousands on both the free and paid tiers. 

Codefresh Helm is a commercial implementation of the open source project by the same name and layers on a lot of functionality for testing configurations, managing releases between environments, etc.