### PR TITLE
Sumo Logic should be listed under Monitoring

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3019,6 +3019,12 @@ landscape:
             logo: ./hosted_logos/stackstate.svg
             crunchbase: 'https://www.crunchbase.com/organization/stackstate'
           - item:
+            name: Sumo Logic
+            homepage_url: 'https://www.sumologic.com/'
+            logo: ./hosted_logos/sumologic.svg
+            twitter: 'https://twitter.com/sumologic'
+            crunchbase: 'https://www.crunchbase.com/organization/sumo-logic'
+          - item:
             name: SysDig
             homepage_url: 'https://sysdig.com/'
             repo_url: 'https://github.com/draios/sysdig'


### PR DESCRIPTION
Sumo Logic provides Monitoring, using metrics and logs. Should also remain listed under "Logging."

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source?
* [ ] If it is open source, does your project have at least 250 GitHub stars?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Are you including an SVG or (less preferably) a large PNG?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] 2 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
