### PR TITLE
Andrey 404 handle an edge case

### DIFF
--- a/src/types/fields.js
+++ b/src/types/fields.js
@@ -164,6 +164,10 @@ const processValuesBeforeLoading = function({options, values}) {
 };
 
 const processValuesBeforeSaving = function({options, values}) {
+  // An edge case here, issue #404
+  if (values.length === 1) {
+    return values;
+  }
   return values.filter(function(value) {
     const option = _.find(options, {id: value});
     // keep parent only if all children are checked


### PR DESCRIPTION
The problem was related to the way how we represent selection in the tree.
Usually both parent and children are selected, but when we want to make header links, we set only a child selected. When there are more than 1 child, this is a correct behaviour, but with only one child, we would have to get a parent selected too. 