### PR TITLE
Update repo_url AppScale

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2582,6 +2582,7 @@ landscape:
           - item:
             name: AppScale
             homepage_url: 'https://www.appscale.com/'
+            repo_url: 'https://github.com/AppScale/appscale'
             logo: ./hosted_logos/appscale.svg
             twitter: 'https://twitter.com/appscalecloud'
             crunchbase: 'https://www.crunchbase.com/organization/appscale-inc'


### PR DESCRIPTION
Forgot to add repo_url of AppScale in previous pull request (AppScale is open source). Sorry about this oversight.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source?
* [ ] If it is open source, does your project have at least 250 GitHub stars?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Are you including an SVG or (less preferably) a large PNG?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] 2 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
