### PR TITLE
Change Couchbase repo to main repo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1142,7 +1142,7 @@ landscape:
           - item:
             name: Couchbase
             homepage_url: 'https://www.couchbase.com/'
-            repo_url: 'https://github.com/couchbase/couchbase-lite-ios'
+            repo_url: 'https://github.com/couchbase/manifest'
             logo: ./hosted_logos/couchbase.svg
             twitter: 'https://twitter.com/couchbase'
             crunchbase: 'https://www.crunchbase.com/organization/couchbase'


### PR DESCRIPTION
Currently the link is pointing to Couchbase Lite.   I've changed it to point to our main repo for the core database.  Alternative, we could have this link point to https://github.com/couchbase, though I'm not sure if you need specific repos rather than orgs here.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source?
* [ ] If it is open source, does your project have at least 250 GitHub stars?
* [x] Have you picked the single best category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Are you including an SVG or (less preferably) a large PNG?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] 2 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
