### PR TITLE
Update Vitess repo URL.

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1333,7 +1333,7 @@ landscape:
             homepage_url: 'https://vitess.io/'
             cncf_project: incubating
             logo: 'https://raw.githubusercontent.com/cncf/artwork/master/vitess/stacked/color/vitess-stacked-color.svg'
-            repo_url: 'https://github.com/youtube/vitess'
+            repo_url: 'https://github.com/vitessio/vitess'
             twitter: 'https://twitter.com/vitessio'
             crunchbase: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'
           - item:


### PR DESCRIPTION
The Vitess repo has moved to a new GitHub org.