### PR TITLE
properly order by a first commit, close #549

### DIFF
--- a/src/types/fields.js
+++ b/src/types/fields.js
@@ -112,6 +112,12 @@ const fields = {
     id: 'firstCommitDate',
     label: 'Project Starting Date',
     url: 'first-commit',
+    orderFn: function(x) {
+      if (x.value) {
+        return x.value;
+      }
+      return x;
+    },
     hideInGrouping: true
   },
   latestCommitDate: {


### PR DESCRIPTION
Fixes the order by first commit issue.
No-Code is not the latest, there is a more recent project.