### PR TITLE
Adding Apache Ignite to the landscape list.

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1252,6 +1252,13 @@ landscape:
             twitter: 'https://twitter.com/ibmdb2'
             crunchbase: 'https://www.crunchbase.com/organization/ibm'
           - item:
+            name: Ignite
+            homepage_url: 'https://ignite.apache.org'
+            repo_url: 'https://github.com/apache/ignite'
+            logo: 'https://ignite.apache.org/images/Ignite_tm_Logo_blk_RGB.svg'
+            twitter: 'https://twitter.com/ApacheIgnite'
+            crunchbase: 'https://www.crunchbase.com/organization/apache'            
+          - item:
             name: iguazio
             homepage_url: 'https://www.iguazio.com/'
             logo: ./hosted_logos/iguazio.svg


### PR DESCRIPTION
Apache Ignite is an ASF project used as a distributed memory-centric database and caching platform for many cloud deployments.
