### PR TITLE
Add LizardFS to Cloud-Native Storage category

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -599,6 +599,13 @@ landscape:
             logo: ./hosted_logos/leofs.svg
             twitter: 'https://twitter.com/LeoFastStorage'
             crunchbase: 'https://www.crunchbase.com/organization/leo-project'
+          - item
+            name: LizardFS
+            homepage_url: 'https://lizardfs.com/'
+            repo_url: 'https://github.com/lizardfs/lizardfs'
+            logo: 'https://lizardfs.com/wp-content/uploads/2016/12/logo-lizardfs-website-purple-300x138.png'
+            twitter: 'https://twitter.com/LizardFS'
+            crunchbase: 'https://www.crunchbase.com/organization/lizardfs-inc'
           - item:
             name: Minio
             homepage_url: 'https://minio.io/'


### PR DESCRIPTION
LizardFS is a Software Defined Storage, similar to GlusterFS, Ceph, OpenEBS.
It works on top of existing filesystem rather than on block device level, so it's much easier to setup.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] 2 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
