### PR TITLE
Rename Telekube to Gravity and include github repo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2281,8 +2281,6 @@ landscape:
             crunchbase: 'https://www.crunchbase.com/organization/red-hat'
           - item:
             name: Gravity
-            description: >-
-              Bring Kubernetes Down to Earth. Gravity is an upstream Kubernetes packaging solution that takes the drama out of on-premise deployments.
             homepage_url: 'https://gravitational.com/gravity/'
             repo_url: 'https://github.com/gravitational/gravity'
             logo: ./hosted_logos/logo-gravity.svg

--- a/landscape.yml
+++ b/landscape.yml
@@ -2280,12 +2280,12 @@ landscape:
             twitter: 'https://twitter.com/coreos'
             crunchbase: 'https://www.crunchbase.com/organization/red-hat'
           - item:
-            name: Telekube
+            name: Gravity
             description: >-
-              Telekube combines a production hardened deployment of Kubernetes with Teleport, our multi-region SSH server, so you can effectively manage
-              multiple deployments of Kubernetes applications across various regions, data centers and cloud providers.
+              Bring Kubernetes Down to Earth. Gravity is an upstream Kubernetes packaging solution that takes the drama out of on-premise deployments.
             homepage_url: 'https://gravitational.com/gravity/'
-            logo: ./hosted_logos/gravitational-telekube.svg
+            repo_url: 'https://github.com/gravitational/gravity'
+            logo: ./hosted_logos/logo-gravity.svg
             crunchbase: 'https://www.crunchbase.com/organization/gravitational'
           - item:
             name: Typhoon

--- a/landscape.yml
+++ b/landscape.yml
@@ -2283,7 +2283,7 @@ landscape:
             name: Gravity
             homepage_url: 'https://gravitational.com/gravity/'
             repo_url: 'https://github.com/gravitational/gravity'
-            logo: ./hosted_logos/logo-gravity.svg
+            logo: https://github.com/gravitational/gravity/blob/master/docs/theme/images/gravity-name.svg
             crunchbase: 'https://www.crunchbase.com/organization/gravitational'
           - item:
             name: Typhoon


### PR DESCRIPTION
Gravitational has renamed Telekube to Gravity and open sourced the code.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~10 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
