### PR TITLE
Adding kitsune to serverless landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3070,6 +3070,12 @@ landscape:
             twitter: 'https://twitter.com/IBMcloud'
             crunchbase: 'https://www.crunchbase.com/organization/ibm'
           - item:
+            name: Kitsune
+            homepage_url: 'https://www.getkitsune.com'
+            logo: 'https://www.getkitsune.com/assets/images/logos/kit-logo.svg'
+            twitter: 'https://twitter.com/getkitsune'
+            crunchbase: 'https://www.crunchbase.com/organization/nowfloats-technologies-private-limited'
+          - item:
             name: Netlify
             homepage_url: 'https://www.netlify.com/'
             logo: 'https://cdn.netlify.com/1e66438712c70d3dfdcfe11f31e467864f94b803/b2c28/img/press/logos/full-logo-light.svg'


### PR DESCRIPTION
kitsune is a programming language that enables any developers to build full stack websites, on serverless architecture on any cloud. Serverless website developed with kitsune are cloud agnostic.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?

LGTM