### PR TITLE
Change Gloo project category

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1197,6 +1197,13 @@ landscape:
             twitter: 'https://twitter.com/datawireio'
             crunchbase: 'https://www.crunchbase.com/organization/datawire'
           - item:
+            name: Gloo
+            homepage_url: 'https://www.solo.io'
+            repo_url: 'https://github.com/solo-io/gloo'
+            logo: gloo.svg
+            twitter: 'https://twitter.com/soloio_inc'
+            crunchbase: 'https://www.crunchbase.com/organization/solo-io'            
+          - item:
             name: Kong
             homepage_url: 'https://konghq.com/'
             repo_url: 'https://github.com/Kong/kong'
@@ -2897,13 +2904,6 @@ landscape:
             logo: event-gateway.svg
             twitter: 'https://twitter.com/goserverless'
             crunchbase: 'https://www.crunchbase.com/organization/serverless'
-          - item:
-            name: Gloo
-            homepage_url: 'https://www.solo.io'
-            repo_url: 'https://github.com/solo-io/gloo'
-            logo: gloo.svg
-            twitter: 'https://twitter.com/soloio_inc'
-            crunchbase: 'https://www.crunchbase.com/organization/solo-io'
           - item:
             name: Hasura GraphQL Engine
             homepage_url: 'https://hasura.io/event-triggers'


### PR DESCRIPTION
Moving gloo to the API Gateway category. It's a better fit.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
