### PR TITLE
Adding EnterpriseDB as database

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1503,7 +1503,13 @@ landscape:
             logo: druid.svg
             twitter: 'https://twitter.com/druidio'
             crunchbase: 'https://www.crunchbase.com/organization/apache'
-          - item:
+       - item:
+            name:  EnterpriseDB
+            homepage_url:'https://www.enterprisedb.com/'
+            logo: enterprisedb.svg
+            twitter: 'https://twitter.com/EDBPostgres'
+            crunchbase: 'https://www.crunchbase.com/organization/enterprisedb'
+       - item:
             name: FoundationDB
             homepage_url: 'https://www.foundationdb.org/'
             repo_url: 'https://github.com/apple/foundationdb'


### PR DESCRIPTION
I would like to add EnterpriseDB to the landscape under databases because we are cloud native, support K8s. I can't import my SVG file to the repo hosted_logos. Can someone help me upload the file, the error message I get when uploading is that i don't have push permissions.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
