### PR TITLE
Remove crunchbase link for MetalLB.

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1249,7 +1249,6 @@ landscape:
             repo_url: 'https://github.com/danderson/metallb'
             logo: metallb.svg
             twitter: 'https://twitter.com/dave_universetf'
-            crunchbase: 'https://www.crunchbase.com/organization/metallb'
           - item:
             name: NGINX
             homepage_url: 'https://www.nginx.com/'


### PR DESCRIPTION
MetalLB is an open source project, not a business. The autogenerated Crunchbase profile was misleading, and I've had it removed.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
