### PR TITLE
Add parent condition to Linux Foundation membership

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -97,8 +97,7 @@ membership:
     name: LF
     label: Project
     funding: Linux Foundation
-    conditions:
-      parent: the-linux-foundation
+    crunchbase_and_children: https://www.crunchbase.com/organization/the-linux-foundation
   cncf:
     name: CNCF
     label: Project


### PR DESCRIPTION
This will allow adding a label for Linux Foundation projects that links to other projects from LF.