### PR TITLE
Hatchway is abandoned by vmware

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -649,14 +649,6 @@ landscape:
             twitter: 'https://twitter.com/GCPcloud'
             crunchbase: 'https://www.crunchbase.com/organization/google'
           - item:
-            name: Hatchway
-            description: >-
-              Project Hatchway address this gap in vSphere environments by offering storage infrastructure choices for container environments, from
-              hyper-converged infrastructure (HCI) powered by VMware vSAN™ to traditional SAN and NAS storage.
-            homepage_url: 'https://vmware.github.io/hatchway/'
-            logo: hatchway.svg
-            crunchbase: 'https://www.crunchbase.com/organization/vmware'
-          - item:
             name: Hedvig
             homepage_url: 'https://www.hedvig.io'
             logo: hedvig.svg


### PR DESCRIPTION
https://github.com/vmware-archive/hatchway

 - item:
            name: Hatchway
            description: >-
              Project Hatchway address this gap in vSphere environments by offering storage infrastructure choices for container environments, from
              hyper-converged infrastructure (HCI) powered by VMware vSAN™ to traditional SAN and NAS storage.
            homepage_url: 'https://vmware.github.io/hatchway/'
            logo: hatchway.svg
            crunchbase: 'https://www.crunchbase.com/organization/vmware'

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
