### PR TITLE
category change for Capsule8

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -307,6 +307,11 @@ landscape:
             logo: 'https://landscape.cncf.io/logos/bloombase.svg'
             crunchbase: 'https://www.crunchbase.com/organization/bloombase'
           - item:
+            name: Capsule8 (member)
+            homepage_url: 'https://capsule8.com/'
+            logo: 'https://www.cncf.io/wp-content/uploads/2018/01/capsule8.svg'
+            crunchbase: 'https://www.crunchbase.com/organization/capsule8'
+          - item:
             name: cert-manager
             homepage_url: 'https://www.jetstack.io/open-source/'
             repo_url: 'https://github.com/jetstack/cert-manager'
@@ -6217,11 +6222,6 @@ landscape:
             homepage_url: 'https://canonical.com/'
             logo: 'https://www.cncf.io/wp-content/uploads/2016/11/canonical-kcsp.svg'
             crunchbase: 'https://www.crunchbase.com/organization/canonical-ltd'
-          - item:
-            name: Capsule8 (member)
-            homepage_url: 'https://capsule8.com/'
-            logo: 'https://www.cncf.io/wp-content/uploads/2018/01/capsule8.svg'
-            crunchbase: 'https://www.crunchbase.com/organization/capsule8'
           - item:
             name: Carbon Relay (member)
             description: 'Carbon Relay provides Red Sky Ops, an AIOps platform for scaling and managing Kubernetes applications using machine learning.'

--- a/landscape.yml
+++ b/landscape.yml
@@ -307,7 +307,7 @@ landscape:
             logo: 'https://landscape.cncf.io/logos/bloombase.svg'
             crunchbase: 'https://www.crunchbase.com/organization/bloombase'
           - item:
-            name: Capsule8 (member)
+            name: Capsule8
             homepage_url: 'https://capsule8.com/'
             logo: 'https://www.cncf.io/wp-content/uploads/2018/01/capsule8.svg'
             crunchbase: 'https://www.crunchbase.com/organization/capsule8'
@@ -6222,6 +6222,11 @@ landscape:
             homepage_url: 'https://canonical.com/'
             logo: 'https://www.cncf.io/wp-content/uploads/2016/11/canonical-kcsp.svg'
             crunchbase: 'https://www.crunchbase.com/organization/canonical-ltd'
+          - item:
+            name: Capsule8 (member)
+            homepage_url: 'https://capsule8.com/'
+            logo: 'https://www.cncf.io/wp-content/uploads/2018/01/capsule8.svg'
+            crunchbase: 'https://www.crunchbase.com/organization/capsule8'
           - item:
             name: Carbon Relay (member)
             description: 'Carbon Relay provides Red Sky Ops, an AIOps platform for scaling and managing Kubernetes applications using machine learning.'


### PR DESCRIPTION
moving Capsule8 from "member" to the "security" category

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [X] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [X] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [X] Have you picked the single best (existing) category for your project?
* [X] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [X] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [X] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [X] Does your project/product name match the text on the logo?
* [X] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
