### PR TITLE
Update NetApp (KCSP) url

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -5417,6 +5417,12 @@ landscape:
             logo: nec.svg
             crunchbase: 'https://www.crunchbase.com/organization/nec'
           - item:
+            name: NetApp (KCSP)
+            description: NetApp offers a wide range of support plans for managed Kubernetes clusters built through its universal control plane for Kubernetes Anywhere.
+            homepage_url: 'https://cloud.netapp.com/home'
+            logo: netapp.svg
+            crunchbase: 'https://www.crunchbase.com/organization/netapp'
+          - item:
             name: Netease (KCSP)
             description: >-
               Netease Cloud provide professional container solution, which integrates IaaS, PaaS and container technology such as Kubernetes and Docker. It

--- a/landscape.yml
+++ b/landscape.yml
@@ -5417,12 +5417,6 @@ landscape:
             logo: nec.svg
             crunchbase: 'https://www.crunchbase.com/organization/nec'
           - item:
-            name: NetApp (KCSP)
-            description: NetApp offers a wide range of support plans for managed Kubernetes clusters built through its universal control plane for Kubernetes Anywhere.
-            homepage_url: 'https://nks.netapp.io'
-            logo: netapp.svg
-            crunchbase: 'https://www.crunchbase.com/organization/netapp'
-          - item:
             name: Netease (KCSP)
             description: >-
               Netease Cloud provide professional container solution, which integrates IaaS, PaaS and container technology such as Kubernetes and Docker. It


### PR DESCRIPTION
NKS is no longer available so the url for NetApp (KCSP) is no longer valid. Updated to point to a proper url.
https://www.storagereview.com/news/netapp-kubernetes-service-nks-come-to-an-end

* [x] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
