### PR TITLE
Add repo_url to Porter's entry

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2323,6 +2323,8 @@ landscape:
           - item:
             name: Porter
             homepage_url: 'https://porter.sh/'
+            repo_url: 'https://github.com/getporter/porter'
+            twitter: 'https://twitter.com/get_porter'
             project: sandbox
             logo: porter-sh.svg
             crunchbase: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'


### PR DESCRIPTION
I'm hoping this will fix the detection of our license so it displays as open-source.  I also realized that the twitter entry was defaulting the the CNCF so I'm editing it to use Porter's twitter handle.

**Update: It worked!**  🎉 

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

This is a follow-up to https://github.com/cncf/landscape/pull/1857 check checked all of these boxes. I'm updating the existing entry.

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
