### PR TITLE
Adding KubeCarrier project to the landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2235,6 +2235,15 @@ landscape:
             logo: kots.svg
             crunchbase: 'https://www.crunchbase.com/organization/replicated'
           - item:
+            name: KubeCarrier
+            description: >-
+              KubeCarrier is an open source system for managing applications and services across multiple Kubernetes clusters. It 
+              provides a framework to centralize the management of services and provide these services with external users in a self service hub.
+            homepage_url: 'https://github.com/kubermatic/kubecarrier'
+            repo_url: 'https://github.com/kubermatic/kubecarrier'
+            logo: kubercarrier.svg
+            crunchbase: 'https://www.crunchbase.com/organization/kubermatic'
+          - item:
             name: KubeVirt
             homepage_url: 'https://kubevirt.io/'
             project: sandbox


### PR DESCRIPTION
Hi there,

we'd like to add our open source project KubeCarrier to the landscape. 

I am aware we are still below the threshold of 300 stars but we get quite some interest for the project and think it is very future oriented: KubeCarrier provides a central framework utilizing Kubernetes Operators and APIs, allowing users to deliver cloud-native service management from one multi-cloud, multi-cluster hub. To us, automating the application layer is the necessary next step of the cloud native journey. 

More information on the project in here: 
https://www.infoq.com/news/2020/10/kubermatic-announces-kubecarrier/

Looking forward to your feedback. (Uploading the svg now) 

Cheers,

Kristin

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
