### PR TITLE
updated Carvel repo link to point to most relevant project stats

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2315,7 +2315,7 @@ landscape:
             name: Carvel
             description: Carvel provides a set of reliable, single-purpose, composable tools that aid in your application building, configuration, and deployment to Kubernetes.
             homepage_url: https://carvel.dev
-            repo_url: https://github.com/vmware-tanzu/carvel.dev
+            repo_url: https://github.com/vmware-tanzu/carvel-ytt
             logo: carvel.svg
             twitter: https://twitter.com/carvel_dev
             crunchbase: https://www.crunchbase.com/organization/vmware  


### PR DESCRIPTION
Original repo link went to our website repo, which points to all the tool suite but the dev stats listed on the landscape were incorrect, i.e. HTML based. Pointing now directly to one of the tool suite's repos, ytt, for clearer details.

Signed-off-by: Nanci Lancaster <nancil@vmware.com>

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [X] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [X] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [X] Have you picked the single best (existing) category for your project?
* [X] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [X Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [X] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [X] Does your project/product name match the text on the logo?
* [X] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [X] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
