### PR TITLE
Add Gitpod badge to README (one-click dev setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1767/badge)](https://bestpractices.coreinfrastructure.org/projects/1767) [![Dependency Status](https://img.shields.io/david/cncf/landscape.svg?style=flat-square)](https://david-dm.org/cncf/landscape) [![Netlify Status](https://api.netlify.com/api/v1/badges/91337728-8166-4c8f-bc39-9159bf97dcbc/deploy-status)](https://app.netlify.com/sites/landscape/deploys)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cncf/landscape/blob/master/landscape.yml) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1767/badge)](https://bestpractices.coreinfrastructure.org/projects/1767) [![Dependency Status](https://img.shields.io/david/cncf/landscape.svg?style=flat-square)](https://david-dm.org/cncf/landscape) [![Netlify Status](https://api.netlify.com/api/v1/badges/91337728-8166-4c8f-bc39-9159bf97dcbc/deploy-status)](https://app.netlify.com/sites/landscape/deploys)
 
 # Cloud Native Landscape
 


### PR DESCRIPTION
Hi @caniszczyk! 👋 I noticed https://github.com/cncf/landscape/issues/1986 and couldn't resist fixing it. 😇

I didn't find a way to replicate what Netlify does to render the website, so currently this just adds a Gitpod badge that directly opens the `landscape.yml` file in Gitpod:

[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cncf/landscape/blob/master/landscape.yml) ↴
<img width="1552" alt="Screenshot 2021-02-24 at 14 21 24" src="https://user-images.githubusercontent.com/599268/109007182-2872d980-76ac-11eb-94ad-4ceadb8aea57.png">
From there, new contributors can easily:
- Edit `landscape.yml`
- Upload a new logo
- Create a commit / fork the repo / send a PR

🎉

But, Gitpod could be even more useful here. For example, it could automatically render the resulting website in a Preview (or show any build errors in the console). Are there any useful commands that Gitpod could be running for contributors?

Then there is also a larger Gitpod button that I haven't added, but could potentially be helpful near the contributing instructions in the README:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/cncf/landscape/blob/master/landscape.yml)

### Pre-submission checklist:

* [x] (not adding a new project)
* [ ] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
