### PR TITLE
Update Netflix Zuul

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1559,6 +1559,13 @@ landscape:
             repo_url: https://github.com/traefik/traefik
             logo: traefik.svg
             crunchbase: https://www.crunchbase.com/organization/containous
+          - item:
+            name: Netflix Zuul
+            homepage_url: https://github.com/Netflix/zuul
+            repo_url: https://github.com/Netflix/zuul
+            logo: netflix-oss-zuul.svg
+            twitter: https://twitter.com/netflixoss
+            crunchbase: https://www.crunchbase.com/organization/netflix            
       - subcategory:
         name: API Gateway
         items:
@@ -1705,13 +1712,6 @@ landscape:
             logo: meshery.svg
             twitter: https://twitter.com/mesheryio
             crunchbase: https://www.crunchbase.com/organization/layer5
-          - item:
-            name: Netflix Zuul
-            homepage_url: https://github.com/Netflix/zuul
-            repo_url: https://github.com/Netflix/zuul
-            logo: netflix-oss-zuul.svg
-            twitter: https://twitter.com/netflixoss
-            crunchbase: https://www.crunchbase.com/organization/netflix
           - item:
             name: Open Service Mesh
             homepage_url: https://openservicemesh.io/


### PR DESCRIPTION
Move Netflix Zuul from "Service Mesh" to "Service proxy" category.
It's more comparable to Envoy than to Istio, for example.