### PR TITLE
Fix NewRelic logo at landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -4638,7 +4638,7 @@ landscape:
           - item:
             name: New Relic
             homepage_url: https://newrelic.com/
-            logo: newrelic.svg
+            logo: https://newrelic.com/themes/custom/curio/assets/mediakit/NR_logo_Horizontal.svg
             twitter: https://twitter.com/NewRelic
             crunchbase: https://www.crunchbase.com/organization/new-relic
           - item:
@@ -8652,7 +8652,7 @@ landscape:
           - item:
             name: New Relic (member)
             homepage_url: https://newrelic.com
-            logo: newrelic.svg
+            logo: https://newrelic.com/themes/custom/curio/assets/mediakit/NR_logo_Horizontal.svg
             crunchbase: https://www.crunchbase.com/organization/new-relic
           - item:
             name: NexClipper (member)


### PR DESCRIPTION
Hosted NewRelic logo won't show up, so I'm replacing it with external URL from https://newrelic.com/about/media-assets

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
