### PR TITLE
Move Grafana Labs from Silver to Platinum

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7672,6 +7672,11 @@ landscape:
             twitter: https://twitter.com/GCPcloud
             crunchbase: https://www.crunchbase.com/organization/google
           - item:
+            name: Grafana Labs (member)
+            homepage_url: https://grafana.com
+            logo: grafana-labs-member.svg
+            crunchbase: https://www.crunchbase.com/organization/raintank
+          - item:
             name: Huawei (member)
             homepage_url: https://www.huaweicloud.com/en-us/about/about_us.html
             logo: huawei.svg
@@ -8891,11 +8896,6 @@ landscape:
             logo: goldman-sachs-member.svg
             enduser: true
             crunchbase: https://www.crunchbase.com/organization/goldman-sachs
-          - item:
-            name: Grafana Labs (member)
-            homepage_url: https://grafana.com
-            logo: grafana-labs-member.svg
-            crunchbase: https://www.crunchbase.com/organization/raintank
           - item:
             name: Grape Up (member)
             homepage_url: https://grapeup.com


### PR DESCRIPTION
As per https://www.cncf.io/announcements/2021/07/28/cloud-native-computing-foundation-announces-grafana-labs-upgrades-membership-to-platinum/