### PR TITLE
Update homepage url for OpenYurt

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -206,7 +206,7 @@ landscape:
           - item:
             name: OpenYurt
             description: An open platform that extending your native Kubernetes to edge.
-            homepage_url: https://openyurt.io/en-us
+            homepage_url: https://openyurt.io/
             project: sandbox
             repo_url: https://github.com/openyurtio/openyurt
             logo: openyurt.svg


### PR DESCRIPTION
Homepage link of OpenYurt(github.com/openyurtio/openyurt) have changed as following:
https://openyurt.io/en-us --> https://openyurt.io

https://github.com/cncf/cncf.io/issues/501