### PR TITLE
Updated wasmCloud repository

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1815,7 +1815,7 @@ landscape:
             name: wasmCloud
             homepage_url: https://wasmcloud.com
             project: sandbox
-            repo_url: https://github.com/wasmCloud/wasmcloud-otp
+            repo_url: https://github.com/wasmCloud/wasmCloud
             logo: wasmcloud.svg
             twitter: https://twitter.com/wasmcloud
             crunchbase: https://www.crunchbase.com/organization/wasmcloud


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

Last week we submitted wasmCloud to the landscape with our primary runtime repository. We've since made a choice to link to `wasmCloud/wasmCloud` instead as it can serve as a better landing page for the project as a whole.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
