### PR TITLE
Add KTP metadata to landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7900,6 +7900,9 @@ landscape:
             homepage_url: http://www.99cloud.net/en/
             logo: 99-cloud-ktp.svg
             crunchbase: https://www.crunchbase.com/organization/99cloud
+            extra:
+              training_certifications: cka, cks
+              training_type: e-learning, instructor-led
           - item:
             name: Acornsoft (KTP)
             description: >-
@@ -7945,6 +7948,9 @@ landscape:
             homepage_url: https://www.beopenit.com/
             logo: beopenit.svg
             crunchbase: https://www.crunchbase.com/organization/beopenit
+            extra:
+              training_certifications: cka, ckad, cks
+              training_type: e-learning, instructor-led
           - item:
             name: Boer Technology (KTP)
             description: >-
@@ -7953,6 +7959,9 @@ landscape:
             homepage_url: https://www.btech.id/#solutions
             logo: boer-technology.svg
             crunchbase: https://www.crunchbase.com/organization/btech-d630
+            extra:
+              training_certifications: cka, ckad, cks, kcna
+              training_type: instructor-led
           - item:
             name: BoxBoat (KTP)
             description: BoxBoat helps global companies develop, integrate, and deploy applications faster with Kubernetes and emerging ecosystem technologies.
@@ -7986,12 +7995,18 @@ landscape:
             homepage_url: https://www.cloudops.com/kubernetes-cloud-native/
             logo: cloudops.svg
             crunchbase: https://www.crunchbase.com/organization/cloudops
+            extra:
+              training_certifications: cka, ckad
+              training_type: instructor-led
           - item:
             name: CloudYuga (KTP)
             description: CloudYuga provides training and consulting on container and cloud native technologies such as Docker, Kubernetes, and Prometheus.
             homepage_url: https://cloudyuga.guru/explore
             logo: cloudyuga.svg
             crunchbase: https://www.crunchbase.com/organization/cloudyuga
+            extra:
+              training_certifications: cka, ckad, cks, kcna
+              training_type: e-learning, instructor-led
           - item:
             name: Component Soft (KTP)
             description: >-
@@ -8011,6 +8026,9 @@ landscape:
             homepage_url: https://www.conoa.se/utbildning/kubernetes-utbildning/
             logo: conoa.svg
             crunchbase: https://www.crunchbase.com/organization/conoa
+            extra:
+              training_certifications: cka, ckad, cks
+              training_type: instructor-led
           - item:
             name: Container Solutions (KTP)
             description: >-
@@ -8102,6 +8120,9 @@ landscape:
             homepage_url: https://www.entigo.com/et/koolitused/
             logo: entigo.svg
             crunchbase: https://www.crunchbase.com/organization/entigo-0301
+            extra:
+              training_certifications: cka
+              training_type: instructor-led
           - item:
             name: Fullstaq (KTP)
             description: >-
@@ -8110,6 +8131,9 @@ landscape:
             homepage_url: https://fullstaq.com/training/
             logo: fullstaq.svg
             crunchbase: https://www.crunchbase.com/organization/fullstaq
+            extra:
+              training_certifications: cka, ckad, cks
+              training_type: instructor-led
           - item:
             name: Gaia (KTP)
             description: >-
@@ -8206,8 +8230,8 @@ landscape:
             logo: oteemo.svg
             crunchbase: https://www.crunchbase.com/organization/oteemo
             extra:
-              training_certifications: cka, ckad, cks, kcna
-              training_type: e-learning, instructor-led
+              training_certifications: cka, ckad, cks
+              training_type: instructor-led
           - item:
             name: Particule (KTP)
             homepage_url: https://particule.io/en/
@@ -8233,12 +8257,18 @@ landscape:
             homepage_url: http://rx-m.com/training/kubernetes-training/
             logo: rx-m.svg
             crunchbase: https://www.crunchbase.com/organization/rx-m
+            extra:
+              training_certifications: cka, ckad, cks, kcna
+              training_type: instructor-led
           - item:
             name: servicememe (KTP)
             description: servicememe provides Kubernetes training services in the Japan market.
             homepage_url: https://www.servicememe.com/services/training/
             logo: servicememe.svg
             crunchbase: https://www.crunchbase.com/organization/servicememe
+            extra:
+              training_certifications: cka, ckad, cks
+              training_type: e-learning, instructor-led
           - item:
             name: Shinesoft (KTP)
             description: We provide design, development and tech support include; Cloud/Cluster, Network, Server, Security, Monitoring, Data analysis, and AI/IoT


### PR DESCRIPTION
This adds metadata for several KTPs to the landscape database so that they can be pulled in and queried on the cncf site here: https://www.cncf.io/certification/kubernetes-training-partners/