### PR TITLE
Correct the Guide's CI/CD section mention of only 2 CNCF projects

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -1037,12 +1037,14 @@ code repository to production. Like most other areas of computing, the advent of
 development has changed CI/CD systems. Some traditional tools like Jenkins, probably the most 
 prolific CI tool on the market, have [overhauled](https://jenkins-x.io/) themselves entirely to 
 better fit into the Kubernetes ecosystem. Others, like Flux and Argo have pioneered a new way of 
-doing continuous delivery called GitOps.
+doing continuous delivery called GitOps, which the OpenGitOps project is working to define as a
+vendor-neutral standard.
 
 In general, you’ll find projects and products in this space are either (1) CI systems, (2) CD 
 systems, (3) tools that help the CD system decide if the code is ready to be pushed into production, 
-or (4), in the case of Spinnaker and Argo, all three. Argo and Brigade are the only CNCF projects in 
-this space but you can find many more options hosted by the 
+or (4), in the case of Spinnaker and Argo, all three. Flux and Argo are the two CNCF incubating
+projects in this space, along with the CNCF sandbox projects Brigade, Keptn and OpenKruise.
+You can also find many more options hosted by the 
 [Continuous Delivery Foundation](https://cd.foundation/). Look for tools in this space to help 
 your organization automate your path to production.
 


### PR DESCRIPTION
Correcting the Guide's statement that there are ONLY two CNCF projects in the Continuous Integration and Delivery space.  I've added text listing the two incubating and three sandbox projects for tooling, and a mention for the OpenGitOps project which is working on a vendor-neutral definition of GitOps.

Fixes #2399 

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
