### PR TITLE
Fix capitalization of CloudCasa entry

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -9408,7 +9408,7 @@ landscape:
             logo: cloudbolt.svg
             crunchbase: https://www.crunchbase.com/organization/cloudbolt-software
           - item:
-            name: cloudcasa by Catalogic (member)
+            name: CloudCasa by Catalogic (member)
             homepage_url: https://www.catalogicsoftware.com/
             logo: cloudcasa-by-catalogic.svg
             crunchbase: https://www.crunchbase.com/organization/catalogic-software


### PR DESCRIPTION
Fix capitalization of "CloudCasa" in landscape member entry.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
