### PR TITLE
Wasm landscape: add Open Policy Agent (OPA)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -12812,6 +12812,14 @@ landscape:
             repo_url: https://github.com/rustwasm/wasm-pack
             logo: wasm.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+          - item:
+            name: Open Policy Agent (OPA)
+            homepage_url: https://www.openpolicyagent.org/
+            project: graduated
+            repo_url: https://github.com/open-policy-agent/opa
+            logo: opa.svg
+            twitter: https://twitter.com/openpolicyagent
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
       - subcategory:
         name: Packaging, Registries & Application Delivery
         items:


### PR DESCRIPTION
OPA lets you compile your Rego policies in to self-contained
Wasm modules, which can be used with a variety of host platforms.

See https://www.openpolicyagent.org/docs/latest/wasm/

### Pre-submission checklist:

❓ This is merely an expansion: OPA is already in another category. From the pre-submission checklist, it seems like that is not desired...? 🤔 

* [X] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [X] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [X] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [X] Have you added your SVG to `hosted_logos` and referenced it there?
* [X] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [X] Does your project/product name match the text on the logo?
* [X] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
