### PR TITLE
Removing the duplicate entry for wasmCloud

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -12963,16 +12963,3 @@ landscape:
             logo: krustlet.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
-          - item:
-            name: wasmCloud
-            homepage_url: https://wasmcloud.com
-            project: sandbox
-            repo_url: https://github.com/wasmCloud/wasmCloud
-            logo: wasmcloud.svg
-            twitter: https://twitter.com/wasmcloud
-            crunchbase: https://www.crunchbase.com/organization/wasmcloud
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2021-07-13'
-              devstats: https://wasmcloud.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#wasmcloud-logos


### PR DESCRIPTION
wasmCloud was listed twice, once under “Scheduling & Orchestration” and the second time under “Installable Platform” and so shows up twice [here](https://landscape.cncf.io/card-mode?grouping=no&project=hosted). I've removed the instance under "Installable Platform" as discussed with @caniszczyk .