### PR TITLE
Add kubecost to continuous optimisation subcategory

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6625,6 +6625,12 @@ landscape:
             logo: infracost.svg
             crunchbase: https://www.crunchbase.com/organization/infracost
           - item:
+            name: Kubecost
+            homepage_url: https://www.kubecost.com/
+            repo_url: https://github.com/kubecost/cost-model
+            logo: kubecost.svg
+            crunchbase: https://www.crunchbase.com/organization/kubecost
+          - item:
             name: mPLAT
             description: mPLAT offers cloud-type service management functions necessary for businesses.
             homepage_url: https://senjufamily.nri.com/mplat/index.html


### PR DESCRIPTION
Kubecost is currently a member company but their product is not on the
landscape. This adds them to the continuous optimisation subcategory as
they are in a similar space to infracost/cast.ai

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [X] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [X] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [X] Have you picked the single best (existing) category for your project?
* [X] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [X] Have you added your SVG to `hosted_logos` and referenced it there?
* [X] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [X] Does your project/product name match the text on the logo?
* [X] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
