### PR TITLE
put wasm in 2 categories

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2006,6 +2006,7 @@ landscape:
               incubation: '2022-03-21'
           - item:
             name: wasmCloud
+            second_path: Serverless / Installable Platform
             homepage_url: https://wasmcloud.com
             project: sandbox
             repo_url: https://github.com/wasmCloud/wasmCloud


### PR DESCRIPTION
An example for a `wasmCloud`
You can see that it is in both categories
