### PR TITLE
remove kube-green, less than 300 stars

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2039,16 +2039,6 @@ landscape:
             logo: Koordinator.svg
             crunchbase: https://www.crunchbase.com/organization/alibaba-cloud
           - item:
-            name: kube-green
-            homepage_url: https://kube-green.dev/
-            repo_url: https://github.com/kube-green/kube-green
-            logo: kube-green.svg
-            open_source: true
-            description: kube-green is a simple k8s addon that automatically shuts down (some of) your resources when you don't need them.
-            crunchbase: https://www.crunchbase.com/organization/mia-platform
-            extra:
-              blog_url: https://kube-green.dev/blog/
-          - item:
             name: kube-rs
             description: kube-rs is the core Rust ecosystem for building applications against Kubernetes
             homepage_url: https://kube.rs


### PR DESCRIPTION
I made a mistake adding kube-green, it has less than 300 stars

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
