### PR TITLE
landscape: add SpiceDB

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3091,6 +3091,19 @@ landscape:
             logo: snowflake.svg
             crunchbase: https://www.crunchbase.com/organization/snowflake-computing
           - item:
+            name: SpiceDB
+            description: Open source permissions database inspired by Google Zanzibar
+            homepage_url: https://authzed.com/spicedb
+            repo_url: https://github.com/authzed/spicedb
+            logo: authzed.svg
+            twitter: https://twitter.com/authzed
+            crunchbase: https://www.crunchbase.com/organization/authzed
+            extra:
+              stack_overflow_url: https://stackoverflow.com/questions/tagged/spicedb
+              blog_url: https://authzed.com/blog/
+              youtube_url: https://www.youtube.com/channel/UCFeSgZf0rPqQteiTQNGgTPg
+              slack_url: https://authzed.com/discord
+          - item:
             name: Software AG
             description: >-
               With Adabas for LUW, you can deliver extremely high transaction speeds with a fraction of the staff and system resources needed for comparable


### PR DESCRIPTION
This PR adds [SpiceDB](https://github.com/authzed/spicedb) to the landscape.

SpiceDB is a database that's used by various cloud native organizations and has direct integrations with CNCF projects like Kubernetes, Prometheus, OpenTelemetry, gRPC, OPA, Envoy, and I'm sure some others that I'm missing.

As SpiceDB is currently getting a logo designed, I've reused the existing authzed logo as a placeholder in the meantime. I hope this is okay.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
