### PR TITLE
Update Karmada slack URL

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2159,7 +2159,7 @@ landscape:
               dev_stats_url: https://karmada.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#karmada-logos
               mailing_list_url: https://groups.google.com/forum/#!forum/karmada
-              slack_url: https://karmada-io.slack.com/
+              slack_url: https://cloud-native.slack.com/messages/karmada
               chat_channel: '#general'
           - item:
             name: Koordinator


### PR DESCRIPTION
This PR updates the slack URL for the Karmada project which official slack has been moved to CNCF during the donation process(see https://github.com/cncf/toc/issues/721#issuecomment-974302115).

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
