### PR TITLE
Updated maturation dates as per DevStats

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1363,7 +1363,10 @@ landscape:
             homepage_url: http://www.opencurve.io/
             repo_url: https://github.com/opencurve/curve
             logo: curve.svg
+            project: sandbox
             crunchbase: https://www.crunchbase.com/organization/netease-com
+            extra:
+              accepted: '2022-09-14'
           - item:
             name: DataCore Bolt
             homepage_url: https://www.datacore.com/products/bolt-kubernetes-storage/
@@ -3804,8 +3807,11 @@ landscape:
             homepage_url: https://carvel.dev
             repo_url: https://github.com/vmware-tanzu/carvel-ytt
             logo: carvel.svg
+            project: sandbox
             twitter: https://twitter.com/carvel_dev
             crunchbase: https://www.crunchbase.com/organization/vmware
+            extra:
+              accepted: '2022-09-14'
           - item:
             name: Chef Habitat
             homepage_url: https://community.chef.io/tools/chef-habitat

--- a/landscape.yml
+++ b/landscape.yml
@@ -741,6 +741,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2019-08-14'
+              incubation: '2022-03-10'
               dev_stats_url: https://intoto.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#in-toto-logos
               slack_url: https://cloud-native.slack.com/messages/in-toto
@@ -2556,6 +2557,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2020-07-07'
+              incubation: '2020-07-07'
               dev_stats_url: https://contour.devstats.cncf.io/
               slack_url: https://kubernetes.slack.com/messages/contour
           - item:
@@ -2746,6 +2748,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2021-04-13'
+              incubation: '2021-04-13'
               dev_stats_url: https://emissaryingress.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/emissary-ingress
           - item:
@@ -3767,6 +3770,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2020-09-08'
+              incubation: '2022-03-15'
               dev_stats_url: https://backstage.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/backstage
           - item:
@@ -4098,6 +4102,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2020-07-09'
+              incubation: '2020-07-09'
               dev_stats_url: https://operatorframework.devstats.cncf.io/
               youtube_url: https://www.youtube.com/channel/UCxRfXpCVxnotoSGxEpB1hwA
           - item:
@@ -4290,6 +4295,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2019-03-18'
+              archived: '2022-10-19'
               dev_stats_url: https://brigade.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#brigade-logos
               slack_url: https://kubernetes.slack.com/messages/C87MF1RFD
@@ -6015,6 +6021,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2021-11-09'
+              incubation: '2021-11-09'
               dev_stats_url: https://dapr.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#dapr-logos
               blog_url: https://blog.dapr.io/posts
@@ -6334,6 +6341,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2022-03-02'
+              incubation: '2022-03-02'
               dev_stats_url: https://knative.teststats.cncf.io/
               artwork_url: https://github.com/knative/docs/tree/main/docs/images/logo
               stack_overflow_url: https://stackoverflow.com/questions/tagged/knative
@@ -7297,6 +7305,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2020-07-14'
+              incubation: '2022-02-16'
               dev_stats_url: https://chaosmesh.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#chaos-mesh-logos
               blog_url: https://chaos-mesh.org/blog/

--- a/landscape.yml
+++ b/landscape.yml
@@ -95,7 +95,7 @@ landscape:
             logo: cloud-custodian.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://cloudcustodian.devstats.cncf.io/
               incubation: '2022-09-14'
           - item:
@@ -119,6 +119,7 @@ landscape:
             logo: devstream.svg
             crunchbase: https://www.crunchbase.com/organization/merico
             extra:
+              accepted: '2022-06-17'
               dev_stats_url: https://devstream.devstats.cncf.io/
               blog_url: https://blog.devstream.io/
               slack_url: https://cloud-native.slack.com/messages/devstream
@@ -170,6 +171,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2019-03-18'
+              incubating: '2020-09-16'
               dev_stats_url: https://kubeedge.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kubeedge-logos
               mailing_list_url: https://groups.google.com/forum/#!forum/kubeedge
@@ -236,6 +238,7 @@ landscape:
             twitter: https://twitter.com/metal3_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2020-09-08'
               dev_stats_url: https://metal3.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/metal3
               blog_url: https://metal3.io/blog/index.html
@@ -265,6 +268,7 @@ landscape:
             logo: openyurt.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2020-09-08'
               dev_stats_url: https://openyurt.devstats.cncf.io/
           - item:
             name: Pulumi
@@ -378,6 +382,8 @@ landscape:
             repo_url: https://github.com/distribution/distribution
             logo: distribution.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-01-26'
           - item:
             name: Dragonfly
             homepage_url: https://d7y.io/
@@ -387,7 +393,8 @@ landscape:
             twitter: https://twitter.com/dragonfly_oss
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2018-11-15'
+              accepted: '2018-11-13'
+              incubating: '2020-04-09'
               dev_stats_url: https://dragonfly.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#dragonfly-logos
               mailing_list_url: https://groups.google.com/g/dragonfly-developers
@@ -411,6 +418,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-07-31'
+              incubating: '2018-11-14'
+              graduated: '2020-06-15'
               dev_stats_url: https://harbor.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#harbor-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/harbor
@@ -601,7 +610,7 @@ landscape:
             logo: containerssh.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-09-13'
+              accepted: '2022-09-14'
               dev_stats_url: https://containerssh.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/containerssh
               slack_url: https://cloud-native.slack.com/
@@ -638,7 +647,7 @@ landscape:
             logo: dex.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://dex.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#dex-logos
           - item:
@@ -673,6 +682,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-10-10'
+              incubating: '2020-01-08'
               dev_stats_url: https://falco.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#falco-logos
               slack_url: https://kubernetes.slack.com/messages/falco
@@ -730,7 +740,7 @@ landscape:
             logo: in-toto.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2019-08-21'
+              accepted: '2019-08-14'
               dev_stats_url: https://intoto.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#in-toto-logos
               slack_url: https://cloud-native.slack.com/messages/in-toto
@@ -778,7 +788,7 @@ landscape:
             logo: kubearmor.svg
             crunchbase: https://www.crunchbase.com/organization/accuknox
             extra:
-              accepted: '2021-11-15'
+              accepted: '2021-11-16'
               dev_stats_url: https://kubearmor.devstats.cncf.io/
               blog_url: https://blog.accuknox.com/tag/kubearmor/
               youtube_url: https://www.youtube.com/watch?v=NS8XC78wSME
@@ -795,7 +805,7 @@ landscape:
             twitter: https://twitter.com/kubewarden
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-07-15'
+              accepted: '2022-06-17'
               blog_url: https://kubewarden.io/blog
               slack_url: https://kubernetes.slack.com/
               dev_stats_url: https://kubewarden.devstats.cncf.io/
@@ -810,7 +820,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2020-11-10'
-              incubating: '2022-07-12'
+              incubating: '2022-07-13'
               dev_stats_url: https://kyverno.devstats.cncf.io/
               slack_url: https://kubernetes.slack.com/
               chat_channel: '#kyverno'
@@ -844,6 +854,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-10-24'
+              incubating: '2017-10-24'
               dev_stats_url: https://notary.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#notary-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/notary
@@ -857,6 +868,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-03-29'
+              incubating: '2019-04-02'
+              graduated: '2021-01-29'
               dev_stats_url: https://opa.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#opa-logos
               stack_overflow_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#opa-logos
@@ -872,7 +885,7 @@ landscape:
             twitter: https://twitter.com/OpenFGA
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-09-13'
+              accepted: '2022-09-14'
               dev_stats_url: https://openfga.devstats.cncf.io/
               artwork_url: https://github.com/openfga/community/tree/main/brand-assets
               slack_url: https://discord.gg/8naAwJfWN6
@@ -906,7 +919,7 @@ landscape:
             logo: parsec.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://parsec.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#parsec-logos
           - item:
@@ -1076,6 +1089,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-10-24'
+              incubating: '2017-10-24'
+              graduated: '2019-12-18'
               dev_stats_url: https://tuf.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#tuf-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/the-update-framework
@@ -1185,6 +1200,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-03-29'
+              incubating: '2020-06-22'
               graduated: '2022-08-23'
               dev_stats_url: https://spiffe.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#spiffe-logos
@@ -1201,6 +1217,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-03-29'
+              incubating: '2020-06-22'
               graduated: '2022-08-22'
               dev_stats_url: https://spire.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#spire-logos
@@ -1233,6 +1250,7 @@ landscape:
             logo: teller.svg
             crunchbase: https://www.crunchbase.com/organization/spectral-4f70
             extra:
+              accepted: '2022-04-26'
               mailing_list_url: https://github.com/SpectralOps/teller/discussions
           - item:
             name: Vault
@@ -1331,8 +1349,8 @@ landscape:
             twitter: https://twitter.com/ChubaoFS
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2019-12-17'
-              incubated: '2022-06-02'
+              accepted: '2019-12-16'
+              incubating: '2022-07-03'
               dev_stats_url: https://chubaofs.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#cubefs-logos
               slack_url: https://cubefs.slack.com/
@@ -1496,6 +1514,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2019-10-11'
+              incubating: '2021-11-04'
               dev_stats_url: https://longhorn.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#longhorn-logos
           - item:
@@ -1556,6 +1575,7 @@ landscape:
             twitter: https://twitter.com/orasproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2021-07-13'
               dev_stats_url: https://oras.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#oras-logos
               blog_url: https://oras.land/blog/
@@ -1572,6 +1592,8 @@ landscape:
             repo_url: https://github.com/piraeusdatastore/piraeus
             logo: piraeus.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-01-26'
           - item:
             name: Portworx
             homepage_url: https://portworx.com/
@@ -1618,6 +1640,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-01-29'
+              incubating: '2018-09-25'
+              graduated: '2020-10-07'
               dev_stats_url: https://rook.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#rook-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/rook
@@ -1700,6 +1724,8 @@ landscape:
             repo_url: https://github.com/v6d-io/v6d
             logo: vineyard.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-04-28'
           - item:
             name: XSKY
             description: >-
@@ -1734,6 +1760,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-03-29'
+              incubating: '2017-03-29'
+              graduated: '2019-02-28'
               dev_stats_url: https://containerd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#containerd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/containerd
@@ -1748,6 +1776,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2019-04-08'
+              incubating: '2019-04-08'
               dev_stats_url: https://crio.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#cri-o-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/cri-o
@@ -1793,7 +1822,7 @@ landscape:
             logo: lima.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-09-13'
+              accepted: '2022-09-14'
               dev_stats_url: https://lima.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#lima-logos
               slack_url: https://slack.cncf.io/
@@ -1812,7 +1841,8 @@ landscape:
             logo: rkt.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2019-08-16'
+              accepted: '2017-03-29'
+              archived: '2019-08-16'
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/archived.md#rkt-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/rkt
               mailing_list_url: https://groups.google.com/forum/?hl=en#!forum/rkt-dev
@@ -1868,6 +1898,8 @@ landscape:
             logo: antrea.svg
             twitter: https://twitter.com/projectantrea
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-04-28'
           - item:
             name: Aviatrix
             homepage_url: https://www.aviatrix.com/
@@ -1895,7 +1927,7 @@ landscape:
             logo: cni-genie.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://cnigenie.devstats.cncf.io/
           - item:
             name: Container Network Interface (CNI)
@@ -1906,6 +1938,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-05-23'
+              incubating: '2017-05-23'
               dev_stats_url: https://cni.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#cni-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/cni
@@ -1929,6 +1962,8 @@ landscape:
             repo_url: https://github.com/FabEdge/fabedge
             logo: fabedge.svg
             crunchbase: https://www.crunchbase.com/organization/bocloud
+            extra:
+              accepted: '2022-03-08'
           - item:
             name: FD.io
             homepage_url: https://fd.io/
@@ -2031,6 +2066,8 @@ landscape:
             logo: submariner.svg
             twitter: https://twitter.com/submarinerio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-04-28'
           - item:
             name: Tungsten Fabric
             homepage_url: https://tungsten.io
@@ -2104,7 +2141,7 @@ landscape:
             logo: clusterpedia.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: 2022-6-14
+              accepted: '2022-6-17'
               dev_stats_url: https://clusterpedia.devstats.cncf.io/
               slack_url: https://cloud-native.slack.com/messages/clusterpedia
           - item:
@@ -2116,7 +2153,8 @@ landscape:
             twitter: https://twitter.com/crossplane_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
+              incubating: '2021-09-14'
               dev_stats_url: https://crossplane.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#crossplane
               youtube_url: https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw
@@ -2135,6 +2173,8 @@ landscape:
             repo_url: https://github.com/fluid-cloudnative/fluid
             logo: fluid.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-04-28'
           - item:
             name: iSSCloud
             description: >-
@@ -2205,7 +2245,9 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
-              accepted: '2016-03-16'
+              accepted: '2016-03-10'
+              incubating: '2016-03-10'
+              graduated: '2018-03-06'
               dev_stats_url: https://k8s.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#kubernetes-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/kubernetes
@@ -2225,7 +2267,7 @@ landscape:
             twitter: https://twitter.com/kubereboot
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-09-13'
+              accepted: '2022-09-14'
               dev_stats_url: https://kured.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kured-logos
               slack_url: http://slack.cncf.io/
@@ -2271,7 +2313,7 @@ landscape:
             twitter: https://twitter.com/volcano_sh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-04-10'
+              accepted: '2020-04-09'
               dev_stats_url: https://volcano.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#volcano
               incubation: '2022-03-21'
@@ -2320,6 +2362,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-02-27'
+              incubating: '2018-02-26'
+              graduated: '2019-01-24'
               dev_stats_url: https://coredns.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#coredns-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/coredns
@@ -2337,6 +2381,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-12-11'
+              incubating: '2018-12-11'
+              graduated: '2020-11-24'
               dev_stats_url: https://etcd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#etcd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/etcd
@@ -2351,6 +2397,7 @@ landscape:
             logo: k8gb.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2021-03-30'
               dev_stats_url: https://k8gb.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#k8gb-logos
               slack_url: https://cloud-native.slack.com/messages/k8gb
@@ -2422,6 +2469,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-02-16'
+              incubating: '2017-02-16'
               dev_stats_url: https://grpc.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#grpc-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/grpc
@@ -2479,7 +2527,7 @@ landscape:
             twitter: https://twitter.com/BfeNetworks
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://bfe.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#bfe-logos
           - item:
@@ -2520,6 +2568,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-09-13'
+              incubating: '2017-09-13'
+              graduated: '2018-11-28'
               dev_stats_url: https://envoy.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#envoy-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/envoyproxy
@@ -2558,6 +2608,7 @@ landscape:
             twitter: https://twitter.com/dave_universetf
             crunchbase: https://www.crunchbase.com/organization/metallb
             extra:
+              accepted: '2021-09-14'
               slack_url: https://slack.k8s.io/
               chat_channel: '#metallb'
           - item:
@@ -2589,6 +2640,7 @@ landscape:
             twitter: https://twitter.com/kubesphere
             crunchbase: https://www.crunchbase.com/organization/qingcloud
             extra:
+              accepted: '2021-11-09'
               slack_url: https://kubernetes.slack.com/messages/openelb
               chat_channel: '#openelb'
           - item:
@@ -2693,7 +2745,7 @@ landscape:
             logo: emissary-ingress.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2021-03-26'
+              accepted: '2021-04-13'
               dev_stats_url: https://emissaryingress.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/emissary-ingress
           - item:
@@ -2783,6 +2835,7 @@ landscape:
             logo: aeraki-mesh.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2022-06-17'
               dev_stats_url: https://aerakimesh.devstats.cncf.io/
               blog_url: https://www.aeraki.net/blog/
               slack_url: https://cloud-native.slack.com/messages/aeraki-mesh
@@ -2834,8 +2887,8 @@ landscape:
             twitter: https://twitter.com/IstioMesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-09-28'
-              incubating: '2022-09-28'
+              accepted: '2022-09-30'
+              incubating: '2022-09-30'
               dev_stats_url: https://istio.devstats.cncf.io/
               stack_overflow_url: https://stackoverflow.com/questions/tagged/istio
               blog_url: https://istio.io/blog/
@@ -2850,7 +2903,7 @@ landscape:
             twitter: https://twitter.com/KumaMesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://kuma.devstats.cncf.io/
           - item:
             name: Linkerd
@@ -2862,6 +2915,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-01-23'
+              incubating: '2018-04-06'
+              graduated: '2021-07-28'
               dev_stats_url: https://linkerd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#linkerd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/linkerd
@@ -2894,6 +2949,7 @@ landscape:
             twitter: https://twitter.com/mesheryio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2021-06-22'
               dev_stats_url: https://meshery.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#meshery-logos
               blog_url: https://meshery.io/blog/
@@ -2909,6 +2965,7 @@ landscape:
             twitter: https://twitter.com/openservicemesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2020-09-08'
               dev_stats_url: https://openservicemesh.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#open-service-mesh-logos
               blog_url: https://openservicemesh.io/blog/
@@ -2922,6 +2979,8 @@ landscape:
             logo: service-mesh-interface.svg
             twitter: https://twitter.com/smi_spec
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2020-03-19'
           - item:
             name: Service Mesh Performance
             homepage_url: https://smp-spec.io/
@@ -2931,6 +2990,7 @@ landscape:
             twitter: https://twitter.com/smp_spec
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2021-06-22'
               dev_stats_url: https://smp.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#service-mesh-performance-logos
               slack_url: https://cloud-native.slack.com/messages/service-mesh-performance
@@ -3339,6 +3399,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-08-28'
+              incubating: '2018-08-28'
+              graduated: '2020-09-02'
               dev_stats_url: https://tikv.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#tikv-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/tikv
@@ -3376,6 +3438,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-02-05'
+              graduated: '2019-11-05'
               dev_stats_url: https://vitess.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#vitess-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/vitess
@@ -3487,7 +3550,8 @@ landscape:
             twitter: https://twitter.com/cloudeventsio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2018-05-22'
+              accepted: '2018-05-15'
+              incubating: '2019-10-24'
               dev_stats_url: https://cloudevents.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#cloudevents-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/cloudevents
@@ -3565,6 +3629,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-03-15'
+              incubating: '2018-03-15'
               dev_stats_url: https://nats.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#nats-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/nats.io
@@ -3595,6 +3660,7 @@ landscape:
             twitter: https://twitter.com/PravegaIO
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2020-11-10'
               dev_stats_url: https://pravega.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#pravega-logos
               blog_url: https://blog.pravega.io/
@@ -3670,6 +3736,7 @@ landscape:
             twitter: https://twitter.com/TremorDEBS
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2020-09-08'
               dev_stats_url: https://tremor.devstats.cncf.io/
       - subcategory:
         name: Application Definition & Image Build
@@ -3688,7 +3755,7 @@ landscape:
             twitter: https://twitter.com/cncfartifacthub
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://cnigenie.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#artifact-hub-logos
           - item:
@@ -3721,6 +3788,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-10-03'
+              incubating: '2020-11-18'
               dev_stats_url: https://buildpacks.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#buildpacks-logos
               slack_url: https://slack.buildpacks.io/
@@ -3768,6 +3836,7 @@ landscape:
             logo: devfile.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2022-01-11'
               slack_url: https://kubernetes.slack.com/messages/devfile
               chat_channel: '#devfile'
           - item:
@@ -3825,7 +3894,9 @@ landscape:
             twitter: https://twitter.com/helmpack
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2016-01-18'
+              accepted: '2018-06-01'
+              incubating: '2018-06-01'
+              graduated: '2020-05-01'
               dev_stats_url: https://helm.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#helm-logos
               slack_url: slack.k8s.io
@@ -3903,6 +3974,8 @@ landscape:
             logo: kubevela.svg
             twitter: https://twitter.com/oam_dev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-06-22'
           - item:
             name: KubeVirt
             homepage_url: https://kubevirt.io/
@@ -3912,7 +3985,7 @@ landscape:
             twitter: https://twitter.com/kubevirt
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2019-09-09'
+              accepted: '2019-09-06'
               dev_stats_url: https://kubevirt.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kubevirt-logos
               youtube_url: https://www.youtube.com/channel/UC2FH36TbZizw25pVT1P3C3g
@@ -3925,7 +3998,7 @@ landscape:
             twitter: https://twitter.com/kudobuilder
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
               dev_stats_url: https://kudo.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kudo
           - item:
@@ -3969,7 +4042,7 @@ landscape:
             logo: nocalhost.svg
             crunchbase: https://www.crunchbase.com/organization/coding-2
             extra:
-              accepted: '2021-11-17'
+              accepted: '2021-11-16'
               dev_stats_url: https://nocalhost.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/nocalhost
               blog_url: https://nocalhost.dev/blog
@@ -4128,7 +4201,7 @@ landscape:
             twitter: https://twitter.com/telepresenceio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2018-05-22'
+              accepted: '2018-05-15'
               dev_stats_url: https://telepresence.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#telepresence-logos
               slack_url: https://d6e.co/slack
@@ -4177,7 +4250,8 @@ landscape:
             twitter: https://twitter.com/argoproj
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-04-07'
+              accepted: '2020-03-26'
+              incubating: '2020-03-26'
               dev_stats_url: https://argo.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/argo
               stack_overflow_url: https://stackoverflow.com/questions/tagged/argoproj+or+argo
@@ -4334,6 +4408,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2019-07-15'
+              incubating: '2021-03-12'
               dev_stats_url: https://flux.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#flux-logos
               blog_url: https://fluxcd.io/blog/
@@ -4425,8 +4500,8 @@ landscape:
             twitter: https://twitter.com/keptnproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
-              incubated: '2022-06-03'
+              accepted: '2020-06-25'
+              incubating: '2022-07-13'
               dev_stats_url: https://keptn.devstats.cncf.io/
               youtube_url: https://www.youtube.com/channel/UCHMn9HyAMeb81bRlaOuZyuQ
               slack_url: https://slack.keptn.sh/
@@ -4455,7 +4530,7 @@ landscape:
             twitter: https://twitter.com/openfeature
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2022-06-14'
+              accepted: '2022-06-17'
               dev_stats_url: https://openfeature.devstats.cncf.io/
               blog_url: https://docs.openfeature.dev/blog
               slack_url: https://cloud-native.slack.com/messages/openfeature
@@ -4475,6 +4550,8 @@ landscape:
             repo_url: https://github.com/openkruise/kruise
             logo: OpenKruise.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2020-11-10'
           - item:
             name: Ortelius
             homepage_url: https://ortelius.io/
@@ -5884,6 +5961,8 @@ landscape:
             repo_url: https://github.com/serverless-devs/serverless-devs
             logo: serverless-devs.svg
             crunchbase: https://www.crunchbase.com/organization/alibaba
+            extra:
+              accepted: '2022-09-14'
           - item:
             name: Sigma
             description: Sigma is a serverless application developer tool; a cloud IDE, which helps you rapidly build, test and deploy serverless applications.
@@ -5935,7 +6014,7 @@ landscape:
             twitter: https://twitter.com/DaprDev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2021-11-03'
+              accepted: '2021-11-09'
               dev_stats_url: https://dapr.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#dapr-logos
               blog_url: https://blog.dapr.io/posts
@@ -6234,7 +6313,8 @@ landscape:
             twitter: https://twitter.com/kedaorg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-03-09'
+              accepted: '2020-03-12'
+              incubating: '2021-08-18'
               dev_stats_url: https://keda.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#keda-logos
               blog_url: https://keda.sh/blog
@@ -6276,6 +6356,8 @@ landscape:
             twitter: https://twitter.com/krustlet
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            extra:
+              accepted: '2021-07-13'
           - item:
             name: Kubeless
             homepage_url: https://github.com/vmware-archive/kubeless-website
@@ -6304,6 +6386,7 @@ landscape:
             logo: openfunction.svg
             crunchbase: https://www.crunchbase.com/organization/qingcloud
             extra:
+              accepted: '2022-04-26'
               slack_url: https://slack.cncf.io/
               chat_channel: '#openfunction'
           - item:
@@ -6328,7 +6411,7 @@ landscape:
             twitter: https://twitter.com/virtualkubelet
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2018-04-12'
+              accepted: '2018-12-04'
               dev_stats_url: https://virtualkubelet.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#virtual-kubelet-logos
   - category:
@@ -6460,6 +6543,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-09-20'
+              incubating: '2020-08-20'
               dev_stats_url: https://cortex.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#cortex-logos
               slack_url: https://cloud-native.slack.com/messages/cortex/
@@ -6504,6 +6588,8 @@ landscape:
             repo_url: https://github.com/foniod/foniod
             logo: fonio.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-03-30'
           - item:
             name: Google Stackdriver
             description: >-
@@ -6601,6 +6687,8 @@ landscape:
             repo_url: https://github.com/kuberhealthy/kuberhealthy
             logo: kuberhealthy.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-03-30'
           - item:
             name: LeanIX Microservice Intelligence (MI)
             description: >-
@@ -6689,6 +6777,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2018-08-10'
+              incubating: '2022-02-03'
               dev_stats_url: https://openmetrics.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#openmetrics-logos
               slack_url: https://cloud-native.slack.com/messages/openmetrics
@@ -6737,6 +6826,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2016-05-09'
+              incubating: '2016-05-09'
+              graduated: '2018-08-09'
               dev_stats_url: https://prometheus.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#prometheus-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/prometheus
@@ -6802,6 +6893,8 @@ landscape:
             repo_url: https://github.com/skooner-k8s/skooner
             logo: skooner.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-01-26'
           - item:
             name: Sosivio
             description: >-
@@ -6832,7 +6925,8 @@ landscape:
             twitter: https://twitter.com/ThanosMetrics
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2019-07-20'
+              accepted: '2019-07-14'
+              incubating: '2020-08-19'
               dev_stats_url: https://thanos.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#thanos-logos
               slack_url: https://cloud-native.slack.com/messages/CK5RSSC10
@@ -6929,6 +7023,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2016-11-08'
+              incubating: '2016-11-08'
+              graduated: '2019-04-11'
               dev_stats_url: https://fluentd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#fluentd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/fluentd
@@ -7100,6 +7196,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2017-09-13'
+              incubating: '2017-09-13'
+              graduated: '2019-10-31'
               dev_stats_url: https://jaeger.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#jaeger-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/jaeger
@@ -7120,7 +7218,8 @@ landscape:
             twitter: https://twitter.com/opentelemetry
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2019-05-17'
+              accepted: '2019-05-07'
+              incubating: '2021-08-26'
               dev_stats_url: https://opentelemetry.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#opentelemetry-logos
               slack_url: https://cloud-native.slack.com/messages/opentelemetry
@@ -7135,6 +7234,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2016-10-11'
+              incubating: '2016-10-11'
               dev_stats_url: https://opentracing.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#opentracing-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/opentracing
@@ -7217,6 +7317,8 @@ landscape:
             logo: chaosblade.svg
             twitter: https://twitter.com/ChaosbladeI
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2021-04-28'
           - item:
             name: chaoskube
             homepage_url: https://github.com/linki/chaoskube
@@ -7239,7 +7341,8 @@ landscape:
             twitter: https://twitter.com/litmuschaos
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
-              accepted: '2020-06-23'
+              accepted: '2020-06-25'
+              incubating: '2022-01-11'
               dev_stats_url: https://litmuschaos.devstats.cncf.io/
               slack_url: https://kubernetes.slack.com/messages/CNXNB0ZTN
               youtube_url: https://www.youtube.com/channel/UCa57PMqmz_j0wnteRa9nCaw
@@ -7321,6 +7424,7 @@ landscape:
             logo: opencost.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              accepted: '2022-06-17'
               slack_url: https://slack.cncf.io/
               chat_channel: '#opencost'
           - item:
@@ -14174,6 +14278,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              accepted: '2021-04-28'
               slack_url: https://cloud-native.slack.com/
               chat_channel: '#WasmEdge'
           - item:


### PR DESCRIPTION
In prep for creating [a chart of CNCF projects over time](https://github.com/cncf/cncf.io/issues/524), I've added maturation dates as per [the Devstats records](https://github.com/cncf/devstats/blob/master/projects.yaml). When there was a discrepancy between existing dates, I favored the Devstats date. Note that Devstats needs updating in several cases where projects were being listed as being in "Sandbox" when they are listed as "Incubating" in landscape (cc @lukaszgryglicki). There were also other questions that came up:

- when did Cloud Custodian go incubating?
- what date was Brigade archived?
- what date did in-toto go to incubating?
- when did Volcano go to incubating?
- when did Contour go to incubating?
- when did Operator Framework go to incubating?
- when did Chaos Mesh go to incubating?
- when did Backstage go to incubating?
- when did Emissary-Ingress go to incubating?
- when did Dapr go to incubating?
- when did Knative go to incubating?
- Is Curve a CNCF project? In landscape it is not listed as one but it is in Devstats.
- Is Armada a CNCF project? In landscape it is not listed as one but it is in Devstats.
- Is Carvel a CNCF project? In landscape it is not listed as one but it is in Devstats.

@caniszczyk could you help answer these?
