### PR TITLE
Add Sedai to serverless landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6057,6 +6057,12 @@ landscape:
             logo: scar.svg
             crunchbase: https://www.crunchbase.com/organization/polytechnic-university-of-valencia
           - item:
+            name: Sedai
+            description: Sedai for Serverless is an autonomous cloud management platform that helps serverless users optimize performance, cost and availability using machine learning
+            logo: sedai.svg
+            twitter: https://twitter.com/sedai_io
+            crunchbase: https://www.crunchbase.com/organization/sedai
+          - item:
             name: Serverless Devs
             homepage_url: https://www.serverless-devs.com/
             project: sandbox


### PR DESCRIPTION
Follow up to original PR now that Sedai is included in Continuous Optimization on primary landscape.

Signed-off-by: John Jamie <john.jamie@gmail.com>

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
