### PR TITLE
Initial creation of go utils for cncf/landscape

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - run: go run cmd/main.go verify
+      - run: go run cmd/main.go verify --file landscape.yml

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,23 @@
+name: Verify
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.17', '1.18', '1.19' ]
+    name: Go ${{ matrix.go }} sample
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go run cmd/main.go verify

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/cncf/landscape/cmd/verify"
+	"github.com/spf13/cobra"
+)
+
+var root = &cobra.Command{
+	Use:           "landscape",
+	Long:          "Command line tool for the CNCF Landscape.",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	// Add the command line flags:
+
+	root.AddCommand(verify.Cmd)
+
+}
+
+func main() {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+
+	// Execute the root command:
+	// root.SetArgs(os.Args[1:])
+	if err := root.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -9,8 +9,8 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "verify",
-	Short: "Verifies the landscape.yml file.",
-	Long:  "Verifies the landscape.yml file.",
+	Short: "Verifies the landscape.yml file against a schema.",
+	Long:  "erifies that the landscape.yaml file exists and that it's contents can be marshaled as yaml.",
 	Args:  cobra.OnlyValidArgs,
 	RunE:  run,
 }
@@ -35,7 +35,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	if err := verify.Verify("landscape.yml"); err != nil {
+	if err := verify.Verify(args.file); err != nil {
 		return err
 	}
 	log.Println("Landscape validated")

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -1,0 +1,43 @@
+package verify
+
+import (
+	"log"
+
+	"github.com/cncf/landscape/pkg/verify"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Verifies the landscape.yml file.",
+	Long:  "Verifies the landscape.yml file.",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
+}
+
+var args struct {
+	file string
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.file,
+		"file",
+		"landscape.yml",
+		"File to validate.",
+	)
+
+	Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yml", "yaml"}, cobra.ShellCompDirectiveDefault
+	})
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	if err := verify.Verify("landscape.yml"); err != nil {
+		return err
+	}
+	log.Println("Landscape validated")
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/cncf/landscape
+
+go 1.19
+
+require (
+	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,40 @@
+package types
+
+type LandscapeList struct {
+	Landscape []struct {
+		Name          string `yaml:"name"`
+		Subcategories []struct {
+			Name  string `yaml:"name"`
+			Items []struct {
+				Name        string `yaml:"name"`
+				HomepageURL string `yaml:"homepage_url"`
+				RepoURL     string `yaml:"repo_url,omitempty"`
+				Logo        string `yaml:"logo"`
+				Twitter     string `yaml:"twitter,omitempty"`
+				Crunchbase  string `yaml:"crunchbase"`
+				Project     string `yaml:"project,omitempty"`
+				Description string `yaml:"description,omitempty"`
+				Extra       struct {
+					Accepted               string `yaml:"accepted"`
+					Incubating             string `yaml:"incubating"`
+					DevStatsURL            string `yaml:"dev_stats_url"`
+					ArtworkURL             string `yaml:"artwork_url"`
+					MailingListURL         string `yaml:"mailing_list_url"`
+					SlackURL               string `yaml:"slack_url"`
+					SummaryPersonas        string `yaml:"summary_personas"`
+					SummaryTags            string `yaml:"summary_tags"`
+					SummaryUseCase         string `yaml:"summary_use_case"`
+					SummaryBusinessUseCase string `yaml:"summary_business_use_case"`
+					SummaryReleaseRate     string `yaml:"summary_release_rate"`
+					SummaryIntegrations    string `yaml:"summary_integrations"`
+					SummaryIntroURL        string `yaml:"summary_intro_url"`
+					BlogURL                string `yaml:"blog_url"`
+					YoutubeURL             string `yaml:"youtube_url"`
+					ChatChannel            string `yaml:"chat_channel"`
+				} `yaml:"extra,omitempty"`
+				Joined              string `yaml:"joined,omitempty"`
+				URLForBestpractices string `yaml:"url_for_bestpractices,omitempty"`
+			} `yaml:"items"`
+		} `yaml:"subcategories"`
+	} `yaml:"landscape"`
+}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -1,0 +1,24 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+
+	types "github.com/cncf/landscape/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+func Verify(f string) error {
+	yamlFile, err := os.ReadFile(f)
+	if err != nil {
+		return fmt.Errorf("yamlFile.Get err   #%v ", err)
+	}
+
+	data := types.LandscapeList{}
+	err = yaml.Unmarshal(yamlFile, &data)
+	if err != nil {
+		return fmt.Errorf("unmarshal error: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
It was a rainy day in Tokyo and I watched sumo while doing this. <3 

- Stubs out a go struct schema for `landscape.yml`
- Creates a golang tooling framework to add functionality to (for future automation)
- Includes a `verify` subcommand which (by default) looks for `landscape.yml` and attempts to verify it against the go struct
- Adds a GitHub action which runs verify on every PR against main

cc @amye @RobertKielty