### PR TITLE
Update slack_url for Prometheus

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7013,7 +7013,7 @@ landscape:
               blog_url: https://prometheus.io/blog/
               mailing_list_url: https://prometheus.io/community/
               youtube_url: https://www.youtube.com/channel/UC4pLFely0-Odea4B2NL1nWA
-              slack_url: https://freenode.net/
+              slack_url: https://libera.chat/
               chat_channel: '#prometheus'
               summary_personas: Cluster Administrators, Developers, SREs, Platform Engineers, Network Engineers
               summary_tags: monitoring, alerting, observability, instrumentation


### PR DESCRIPTION
We moved from freenode to libera.chat a while ago.

Omitting the re-submission checklist because it's just a change of one field.
