### PR TITLE
fix: external-secrets devstats url

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -701,7 +701,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2022-07-26'
-              dev_stats_url: https://external-secrets.devstats.cncf.io/
+              dev_stats_url: https://externalsecretsoperator.devstats.cncf.io/
           - item:
             name: Fairwinds Insights
             homepage_url: https://fairwinds.com/insights


### PR DESCRIPTION
Working towards: https://github.com/external-secrets/external-secrets/issues/1395

This PR fixes the devstats URL of external secrets operator.
URL source from this issue here: https://github.com/cncf/toc/issues/882#issuecomment-1202324717

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
