### PR TITLE
adds check_suite trigger, pins go version

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,7 +1,8 @@
 name: Verify
 
 on:
-  workflow_dispatch:
+  check_suite:
+    types: [completed,requested,rerequested]
   pull_request:
     branches:
       - main
@@ -10,14 +11,11 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.17', '1.18', '1.19' ]
-    name: Go ${{ matrix.go }} sample
+    name: Check that the landscape.yml is syntatically correct
     steps:
       - uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '^go.1.19.5'
       - run: go run cmd/main.go verify --file landscape.yml

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,11 +11,11 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    name: Check that the landscape.yml is syntatically correct
+    name: Check that the landscape.yml is syntactically correct
     steps:
       - uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '^go.1.19.5'
+          go-version: 'go.1.19.5'
       - run: go run cmd/main.go verify --file landscape.yml


### PR DESCRIPTION
### Pre-submission checklist:

Updates the verify GitHub Action on this repo adding a check_suite trigger and also pins the version of go used to run the check to ^1.19.5 when running the go program that checks the correctness of the landscape.yml file.

Post merge this we should then see a verfy step in PRs that checks the landscape.yml file 

cc @jeefy