### PR TITLE
Fix Seatunnel typo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -4355,7 +4355,7 @@ landscape:
             open_source: false
             crunchbase: https://www.crunchbase.com/organization/vectorized
           - item:
-            name: SeaTunnal
+            name: SeaTunnel
             homepage_url: https://seatunnel.apache.org/
             repo_url: https://github.com/apache/incubator-seatunnel
             logo: seatunnel.svg


### PR DESCRIPTION
Fix Seatunnal to Seatunnel.

Signed-off-by: Joris Roovers <joris.roovers@gmail.com>