### PR TITLE
remove inconsistent subdomain for repo url

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6581,14 +6581,6 @@ landscape:
             twitter: null
             crunchbase: https://www.crunchbase.com/organization/cybozu
           - item:
-            name: Flant Deckhouse Installer
-            description: Deckhouse Installer (DHCTL) is an application for creating Kubernetes clusters and configuring their infrastructure.
-            homepage_url: https://github.com/deckhouse/deckhouse
-            repo_url: https://github.com/deckhouse/deckhouse
-            logo: flant-deckhouse.svg
-            twitter: https://www.twitter.com/deckhouseio
-            crunchbase: https://www.crunchbase.com/organization/flant
-          - item:
             name: Gardener
             description: >-
               The Gardener implements automated management and operation of Kubernetes clusters as a service and aims to support that service on multiple  Cloud

--- a/landscape.yml
+++ b/landscape.yml
@@ -4519,7 +4519,7 @@ landscape:
           - item:
             name: StreamSets
             homepage_url: https://streamsets.com/
-            repo_url: https://github.com/streamsets/datacollector
+            repo_url: https://github.com/streamsets/datacollector-oss
             logo: streamsets.svg
             crunchbase: https://www.crunchbase.com/organization/streamsets
           - item:

--- a/landscape.yml
+++ b/landscape.yml
@@ -6583,8 +6583,8 @@ landscape:
           - item:
             name: Flant Deckhouse Installer
             description: Deckhouse Installer (DHCTL) is an application for creating Kubernetes clusters and configuring their infrastructure.
-            homepage_url: https://www.github.com/deckhouse/deckhouse
-            repo_url: https://www.github.com/deckhouse/deckhouse
+            homepage_url: https://github.com/deckhouse/deckhouse
+            repo_url: https://github.com/deckhouse/deckhouse
             logo: flant-deckhouse.svg
             twitter: https://www.twitter.com/deckhouseio
             crunchbase: https://www.crunchbase.com/organization/flant


### PR DESCRIPTION
deckhouse is the only project with www.github.com in hostname . all else are using the proper github.com urls. hence updating it

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
