### PR TITLE
Added summary table fields for etcd

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2973,12 +2973,23 @@ landscape:
               incubating: '2018-12-11'
               graduated: '2020-11-24'
               dev_stats_url: https://etcd.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#etcd-logos
+              artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#etcd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/etcd
               mailing_list_url: https://groups.google.com/forum/?hl=en#!forum/etcd-dev
-              slack_url: https://freenode.net/
+              slack_url: http://slack.k8s.io/
               chat_channel: '#etcd'
               clomonitor_name: etcd
+              summary_personas: Architects, Platform Engineers, SREs
+              summary_tags: distributed, key-value, consistent, datastore, reliability
+              summary_use_case: >
+                Etcd is a distributed, reliable key-value store for the most critical data of a distributed system.
+
+                By using etcd, developers can ensure that their applications have access to up-to-date configuration data, even as they scale up or down, and can maintain consistency, fault tolerance and coordination across multiple instances of the application.
+              summary_business_use_case: >
+                Etcd can be used by businesses to manage the configuration data and coordination needs of their applications, ensuring consistent and reliable performance at scale.
+              summary_release_rate: Every 1-3 months
+              summary_integrations: Due to etcd's flexible and extensible architecture it has been integrated as a data store for many projects such as Kubernetes, CoreDNS and Hashicorp Vault.
+              summary_intro_url: https://etcd.io/docs/v3.6/learning/
           - item:
             name: k8gb
             homepage_url: https://www.k8gb.io


### PR DESCRIPTION
The CNCF Business Value Subcommittee has developed a project summary table to supplement the CNCF Landscape and include further information about CNCF projects for the wider cloud native community. 

This pull request proposes an update for project summary table fields for etcd. This will help further inform the community about etcd and its use cases.

Relates to https://github.com/etcd-io/website/issues/658

Leaving this in draft until etcd maintainers have finished reviewing.

cc @ahrtr , @ptabor , @serathius, @spzala