### PR TITLE
Changed Stackdriver to Google Cloud's Operations Suite LGTM

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7854,9 +7854,9 @@ landscape:
               accepted: '2021-03-30'
               clomonitor_name: fonio
           - item:
-            name: Google Stackdriver
+            name: Google Cloud's Operation Suite
             description: >-
-              Stackdriver aggregates metrics, logs, and events from infrastructure, giving developers and operators a rich set of observable signals that speed
+              Google Cloud's Operation Suite aggregates metrics, logs, and events from infrastructure, giving developers and operators a rich set of observable signals that speed
               root-cause analysis and reduce mean time to resolution (MTTR).
             homepage_url: https://cloud.google.com/products/operations
             logo: google-stackdriver.svg


### PR DESCRIPTION
This is just a change in the name. 
-> Stackdriver to Google Cloud's Operations Suite

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
