### PR TITLE
Add direktiv.io to landscape (logo already exists)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7438,6 +7438,13 @@ landscape:
             twitter: https://twitter.com/Cloudflare
             crunchbase: https://www.crunchbase.com/organization/cloudflare
           - item:
+            name: Direktiv
+            homepage_url: https://www.direktiv.io/
+            repo_url: https://github.com/direktiv/direktiv
+            logo: direktiv.svg
+            twitter: https://twitter.com/direktiv_io
+            crunchbase: https://www.crunchbase.com/organization/direktiv
+          - item:
             name: Google Cloud Functions
             description: >-
               Your development agility comes from building systems composed of small, independent units of functionality focused on doing one thing well. Cloud


### PR DESCRIPTION
### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
