### PR TITLE
Remove the twitter account from metallb

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3472,7 +3472,6 @@ landscape:
             homepage_url: https://metallb.universe.tf
             repo_url: https://github.com/metallb/metallb
             logo: metallb.svg
-            twitter: https://twitter.com/dave_universetf
             crunchbase: https://www.crunchbase.com/organization/metallb
             extra:
               accepted: '2021-09-14'


### PR DESCRIPTION
The twitter account was bound to the MetalLB original maintainer, who is not handling metallb any more.

