### PR TITLE
Update annual review urls in landscape.yml for kube-rs

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3044,7 +3044,6 @@ landscape:
             project: sandbox
             repo_url: https://github.com/kube-rs/kube-rs
             logo: kube-rs.svg
-            twitter: https://twitter.com/kube_rs
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2021-11-16'
@@ -3054,6 +3053,8 @@ landscape:
               chat_channel: '#kube'
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kube-rs-logos
               clomonitor_name: kube-rs
+              annual_review_url: https://github.com/cncf/toc/pull/1087
+              annual_review_date: '2023-06-16'
           - item:
             name: Kubernetes
             description: Kubernetes is an open-source system for automating deployment, scaling, and management of containerized applications


### PR DESCRIPTION
as suggested by CLOMonitor people https://github.com/kube-rs/kube/issues/1219#issuecomment-1611660030
also killed the twitter link which has been defunct since elon.