### PR TITLE
Update devspace repo (they moved to a different org)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -5373,7 +5373,7 @@ landscape:
             name: DevSpace
             homepage_url: https://devspace.sh
             project: sandbox
-            repo_url: https://github.com/devspace-sh/devspace-cloud
+            repo_url: https://github.com/devspace-cloud/devspace-cloud
             logo: devspace.svg
             twitter: https://twitter.com/DevSpace
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation


### PR DESCRIPTION
- https://github.com/devspace-sh/devspace-cloud - does not exist.
- https://github.com/devspace-cloud/devspace-cloud - is the new repo.

cc @caniszczyk @castrojo @AndreyKozlov1984 