### PR TITLE
fix: missing fill attribute of svg in wa logo

### DIFF
--- a/hosted_logos/wa-lang.svg
+++ b/hosted_logos/wa-lang.svg
@@ -1,6 +1,22 @@
+<!--
+// 版权 @2019 凹语言 作者。保留所有权利。
+// https://wa-lang.org
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400" fill="none">
+
   <path fill-rule="evenodd" clip-rule="evenodd" d="M50 70C50 58.9543 58.9543 50 70 50H130C141.046 50 150 58.9543 150 70V74V130V150H250V130V74V70C250 58.9543 258.954 50 270 50H330C341.046 50 350 58.9543 350 70V94V130V330C350 341.046 341.046 350 330 350H70C58.9543 350 50 341.046 50 330V130V94V70Z" fill="LightSeaGreen" />
-  <circle cx="100" cy="100" r="5" stroke="black" stroke-width="0" fill="white"></circle>
-  <circle cx="300" cy="100" r="5" stroke="black" stroke-width="0" fill="white"></circle>
-  <path d="M200 230L234 264L268 230M200 230L166 264L132 230" fill="none" stroke="white" stroke-width="8" stroke-linecap="round" stroke-dasharray="192,0"></path>
+
+  <circle cx="100" cy="100" r="5" stroke="black" stroke-width="0" fill="white">
+    <animate attributeName="r" values="0;5;5;0" dur="1s" repeatCount="1" />
+  </circle>
+
+  <circle cx="300" cy="100" r="5" stroke="black" stroke-width="0" fill="white">
+    <animate attributeName="r" values="0;5;5;0" dur="1s" repeatCount="1" />
+  </circle>
+
+  <path d="M200 230L234 264L268 230M200 230L166 264L132 230" fill="LightSeaGreen" stroke="white" stroke-width="8" stroke-linecap="round" stroke-dasharray="0,0,0,192">
+    <animate attributeType="XML" attributeName="stroke-dasharray" values="0,0,0,192;0,96,96,0; 192,0,0,0" keyTimes="0; 0.5;1" fill="freeze" dur="1.5s" repeatCount="1" />
+  </path>
+
 </svg>


### PR DESCRIPTION
### Pre-submission checklist:

*Fix a problem in logo in wa-lang. In local debug, we found that when executing the build script, the `fill="none"` attribute in the original svg is removed by default, which causes the logo to display incorrectly. After changing to `fill="LightSeaGreen"` (LightSeaGreen is the background color of the logo), the logo is displayed correctly. So fix the fill color of fill in svg so that wa-lang's logo can be displayed correctly.*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
