### PR TITLE
Bump landscape validate action to v2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,7 @@ jobs:
     name: "Validate landscape.yml file"
     steps:
       - uses: actions/checkout@v3
-      - uses: cncf/landscape2-validate-action@v1
+      - uses: cncf/landscape2-validate-action@v2
         with:
-          data_file: ./landscape.yml
+          target_kind: data
+          target_path: ./landscape.yml


### PR DESCRIPTION
We've released a new version of the landscape2-validate-action that adds support for validating `settings` and `guide` files, in addition to `data` files (i.e. *landscape.yml*). The action parameters have changed a bit, hence the new version.