### PR TITLE
Move Flipt from CD to Feature Flags

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6635,15 +6635,6 @@ landscape:
               clomonitor_name: flagger
               summary_integrations: Gateway API + standard service meshes and ingress controllers
           - item:
-            name: Flipt
-            description: Open source, self-hosted, developer first, feature flagging and dynamic configuration service
-            homepage_url: https://flipt.io
-            repo_url: https://github.com/flipt-io/flipt
-            url_for_bestpractices: https://bestpractices.coreinfrastructure.org/en/projects/3498
-            logo: flipt.svg
-            twitter: https://twitter.com/flipt_io
-            crunchbase: https://www.crunchbase.com/organization/flipt-36c0
-          - item:
             name: Flux
             homepage_url: https://fluxcd.io/
             project: graduated
@@ -9616,6 +9607,17 @@ landscape:
               slack_url: https://discord.gg/hFhxNtXzgm
               blog_url: https://www.flagsmith.com/blog
               youtube_url: https://www.youtube.com/channel/UCki7GZrOdZZcsV9rAIRchCw
+          - item:
+            name: Flipt
+            description: Open source, self-hosted, developer first, feature flagging and dynamic configuration service
+            homepage_url: https://flipt.io
+            repo_url: https://github.com/flipt-io/flipt
+            url_for_bestpractices: https://bestpractices.coreinfrastructure.org/en/projects/3498
+            logo: flipt.svg
+            twitter: https://twitter.com/flipt_io
+            crunchbase: https://www.crunchbase.com/organization/flipt-36c0
+            extra:
+              blog_url: https://flipt.io/blog
           - item:
             name: GO Feature Flag
             homepage_url: https://gofeatureflag.org


### PR DESCRIPTION
This is a quick PR to move Flipt from CD to the new Feature Flags category.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
