### PR TITLE
Fixes a bunch of dead urls (#3641)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -599,7 +599,7 @@ landscape:
               audits:
                 - date: '2019-10-01'
                   type: security
-                  url: https://github.com/goharbor/harbor/blob/master/docs/security/Harbor_Security_Audit_Oct2019.pdf
+                  url: https://github.com/goharbor/website/blob/main/docs/security/Harbor_Security_Audit_Oct2019.pdf
                   vendor: Cure53
           - item:
             name: IBM Cloud Container Registry
@@ -666,7 +666,7 @@ landscape:
           - item:
             name: Alcide
             description: Alcide provides dev-to-production security for workloads running in Kubernetes & Istio
-            homepage_url: https://www.alcide.io/
+            homepage_url: https://github.com/alcideio
             logo: alcide.svg
             crunchbase: https://www.crunchbase.com/organization/alcide
           - item:
@@ -901,7 +901,7 @@ landscape:
               clomonitor_name: curiefense
           - item:
             name: Datica
-            homepage_url: https://datica.com/
+            homepage_url: https://www.linkedin.com/company/datica-inc/about/
             logo: datica.svg
             crunchbase: https://www.crunchbase.com/organization/datica
           - item:
@@ -993,7 +993,7 @@ landscape:
               audits:
                 - date: '2019-06-07'
                   type: security
-                  url: https://github.com/falcosecurity/falco/blob/dev/audits/SECURITY_AUDIT_2019_07.pdf
+                  url: https://github.com/falcosecurity/falco/blob/master/audits/SECURITY_AUDIT_2019_07.pdf
                   vendor: Cure53
                 - date: '2023-03-22'
                   type: security
@@ -1099,7 +1099,7 @@ landscape:
               accepted: '2023-04-10'
               incubating: '2023-04-10'
               dev_stats_url: https://keycloak.devstats.cncf.io/
-              artwork_url: https://github.com/keycloak/keycloak-misc/blob/main/logo/keycloak_logo_600px.svg
+              artwork_url: https://github.com/keycloak/keycloak-misc/blob/main/logo/logo-key.svg
               mailing_list_url: https://groups.google.com/forum/#!forum/keycloak-user
               summary_personas: SREs,Cloud Architects,Platform Engineers,Security Engineers,Developers,Architects
               summary_tags: Java,Security,Container,Cloud Native,Kubernetes,SSO,Identity,Federation,Authentication,Authorization
@@ -1194,7 +1194,7 @@ landscape:
             extra:
               accepted: '2021-11-16'
               dev_stats_url: https://kubearmor.devstats.cncf.io/
-              blog_url: https://blog.accuknox.com/tag/kubearmor/
+              blog_url: https://kubearmor.io/blog
               youtube_url: https://www.youtube.com/watch?v=NS8XC78wSME
               docker_url: https://hub.docker.com/r/kubearmor/kubearmor
               github_discussions_url: https://github.com/kubearmor/KubeArmor/discussions
@@ -1549,7 +1549,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/fairwinds
           - item:
             name: Portshift
-            homepage_url: https://www.portshift.io/
+            homepage_url: https://github.com/Portshift
             logo: portshift.svg
             crunchbase: https://www.crunchbase.com/organization/portshift
           - item:
@@ -1861,8 +1861,7 @@ landscape:
               annual_review_date: '2023-06-30'
               dev_stats_url: https://athenz.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/athenz
-              mailing_list_url: https://groups.google.com/d/forum/athenz-users
-              slack_url: https://join.slack.com/t/athenz/
+              slack_url: https://athenz.slack.com/
               clomonitor_name: athenz
           - item:
             name: Authing
@@ -2084,7 +2083,7 @@ landscape:
             description: >-
               Alibaba Cloud File Storage CPFS is a scale-out parallel file system for Artifical intelligence(AI), High performance computing(HPC) workload while
               ensuring security, reliability, data effciency and high performance.
-            homepage_url: https://www.alibabacloud.com/error
+            homepage_url: https://www.alibabacloud.com/
             logo: alibaba-cloud-file-storage-cpfs.svg
             crunchbase: https://www.crunchbase.com/organization/alibaba-cloud
           - item:
@@ -2117,7 +2116,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/microsoft
           - item:
             name: Carina
-            homepage_url: http://www.opencarina.com
+            homepage_url: https://carina-io.github.io/
             project: sandbox
             repo_url: https://github.com/carina-io/carina
             logo: carina.svg
@@ -2178,7 +2177,6 @@ landscape:
                 compatible with the S3 API. Moreover, CubeFS offers personal cloud storage on all your devices.
               summary_release_rate: Every 2 months
               summary_integration: Kubernetes, Helm，Prometheus, Grafana, Docker, Nginx, etc.
-              summary_intro_url: https://ocs-cn-north1.heytapcs.com/cubefs/community/video1657061611.mp4
               clomonitor_name: chubao-fs
           - item:
             name: Curve
@@ -2203,7 +2201,7 @@ landscape:
             description: >-
               DatenLord is a cloud-native distributed storage platform, aiming to meet the performance-critical storage needs from next-generation cloud-native
               applications.
-            homepage_url: https://www.datenlord.io
+            homepage_url: https://datenlord.github.io/
             repo_url: https://github.com/datenlord/datenlord
             logo: datenlord.svg
             crunchbase: https://www.crunchbase.com/organization/beijing-datenlord-technology
@@ -2226,9 +2224,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/diamanti
           - item:
             name: DriveScale
-            homepage_url: https://drivescale.com/
+            homepage_url: https://www.linkedin.com/company/drivescale-inc-/
             logo: drivescale.svg
-            twitter: https://twitter.com/DriveScale_inc
             crunchbase: https://www.crunchbase.com/organization/drivescale
           - item:
             name: ExponTech
@@ -2304,7 +2301,7 @@ landscape:
           - item:
             name: Inspur Storage
             description: Cloud + AI, operate new massive data operations.
-            homepage_url: https://en.inspur.com/en/storage
+            homepage_url: https://www.inspur.com/
             logo: inspur.svg
             crunchbase: https://www.crunchbase.com/organization/inspur
           - item:
@@ -2432,7 +2429,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/nutanix
           - item:
             name: Ondat
-            homepage_url: https://www.ondat.io
+            homepage_url: https://docs.ondat.io/
             logo: ondat.svg
             crunchbase: https://www.crunchbase.com/organization/ondat
           - item:
@@ -2454,7 +2451,7 @@ landscape:
               clomonitor_name: openebs
           - item:
             name: OpenIO
-            homepage_url: https://www.openio.io/
+            homepage_url: https://docs.openio.io/
             repo_url: https://github.com/open-io/oio-sds
             logo: openio.svg
             crunchbase: https://www.crunchbase.com/organization/openio
@@ -2477,7 +2474,7 @@ landscape:
               clomonitor_name: oras
           - item:
             name: Pengyun Network
-            homepage_url: https://www.pengyunnetwork.com/
+            homepage_url: https://www.pengyunnetwork.cn/
             logo: pengyun.svg
             crunchbase: https://www.crunchbase.com/organization/pengyun-network
           - item:
@@ -2686,7 +2683,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/xsky-data-technology
           - item:
             name: YRCloudFile
-            homepage_url: http://www.yanrongyun.com/solution/k8s-storage
+            homepage_url: https://www.yanrongyun.com/en-us/products/yrfs
             logo: yanrong.svg
             crunchbase: https://www.crunchbase.com/organization/yanrong
           - item:
@@ -2780,7 +2777,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/google
           - item:
             name: Inclavare Containers
-            homepage_url: https://inclavare-containers.io/
+            homepage_url: https://github.com/inclavare-containers/
             project: sandbox
             repo_url: https://github.com/inclavare-containers/inclavare-containers
             logo: inclavare.svg
@@ -3055,7 +3052,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/nokia
           - item:
             name: FabEdge
-            homepage_url: https://www.fabedge.io/
+            homepage_url: https://github.com/FabEdge/
             project: sandbox
             repo_url: https://github.com/FabEdge/fabedge
             logo: fabedge.svg
@@ -3408,7 +3405,7 @@ landscape:
               hybrid cloud scenarios. It provides consistent self-service and operation management capabilities  on heterogeneous resources which include
               centralized resource management and control, automated resource delivery, intelligent  operation analysis and O&M management to reduce the costs
               of hybrid cloud management.
-            homepage_url: https://www.isoftstone.com/htmlsen/Cloudnativeservices/20220613/6acf55b26d0c4625b2fb8ca54cee58ab.html
+            homepage_url: https://www.isoftstone.com/
             logo: isscloud.svg
             twitter: null
             crunchbase: https://www.crunchbase.com/organization/isoftstone
@@ -3503,7 +3500,7 @@ landscape:
             extra:
               accepted: '2022-03-02'
               incubating: '2022-03-02'
-              dev_stats_url: https://knative.teststats.cncf.io/
+              dev_stats_url: https://knative.devstats.cncf.io/
               artwork_url: https://github.com/knative/docs/tree/main/docs/images/logo
               stack_overflow_url: https://stackoverflow.com/questions/tagged/knative
               mailing_list_url: https://groups.google.com/d/forum/knative-users
@@ -3560,7 +3557,6 @@ landscape:
             extra:
               accepted: '2021-11-16'
               dev_stats_url: https://kubers.devstats.cncf.io/
-              blog_url: https://kube.rs/blog
               slack_url: https://discord.gg/tokio
               chat_channel: '#kube'
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kube-rs-logos
@@ -3822,7 +3818,7 @@ landscape:
               dev_stats_url: https://coredns.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#coredns-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/coredns
-              blog_url: https://blog.coredns.io/
+              blog_url: https://coredns.io/blog/
               mailing_list_url: https://groups.google.com/forum/#!forum/coredns-discuss
               slack_url: https://cloud-native.slack.com/messages/coredns/
               youtube_url: https://www.youtube.com/channel/UCbWRJZxiaQ8twm6sh7UymoQ
@@ -4131,7 +4127,7 @@ landscape:
               audits:
                 - date: '2018-02-27'
                   type: security
-                  url: https://github.com/envoyproxy/envoy/blob/master/docs/SECURITY_AUDIT.pdf
+                  url: https://github.com/envoyproxy/envoy/blob/main/docs/security/audit_cure53_2018.pdf
                   vendor: Cure53
                 - date: '2021-05-15'
                   type: fuzzing
@@ -4254,7 +4250,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/zalando
           - item:
             name: Snapt Nova
-            homepage_url: https://www.snapt.net/platforms/nova-adc
+            homepage_url: https://github.com/snapt
             logo: nova.svg
             twitter: https://twitter.com/SnaptADC
             crunchbase: https://www.crunchbase.com/organization/snapt
@@ -4296,7 +4292,7 @@ landscape:
             joined: '2021-01-31'
           - item:
             name: APIOAK
-            homepage_url: https://apioak.com/
+            homepage_url: https://github.com/apioak/
             repo_url: https://github.com/apioak/apioak
             logo: apioak.svg
             crunchbase: https://www.crunchbase.com/organization/apioak
@@ -4521,7 +4517,7 @@ landscape:
           - item:
             name: Glasnostic
             description: Glasnostic makes modern cloud applications resilient by shaping how systems interact, automatically and in real-time.
-            homepage_url: https://glasnostic.com/
+            homepage_url: https://www.linkedin.com/company/glasnostic/
             logo: glasnostic.svg
             crunchbase: https://www.crunchbase.com/organization/glasnostic
           - item:
@@ -4584,7 +4580,6 @@ landscape:
               annual_review_date: '2023-06-10'
               dev_stats_url: https://kuma.devstats.cncf.io/
               blog_url: https://kuma.io/blog/
-              slack_url: https://chat.kuma.io/
               summary_business_use_case: >-
                 It is becoming more important then ever to ensure that traffic is secure, observable, and reliable. Kuma service mesh enables users to adopt a
                 zero trust application networking model while providing flexible traffic management and observability capabilities.  Kuma also supports a wide
@@ -4635,7 +4630,7 @@ landscape:
               audits:
                 - date: '2019-06-01'
                   type: security
-                  url: https://github.com/linkerd/linkerd2/blob/master/SECURITY_AUDIT.pdf
+                  url: https://github.com/linkerd/linkerd2/blob/main/audits/2019/SECURITY_AUDIT.pdf
                   vendor: Cure53
                 - date: '2020-06-05'
                   type: security
@@ -4686,7 +4681,6 @@ landscape:
               archived: '2023-06-30'
               annual_review_url: https://github.com/cncf/toc/pull/742
               annual_review_date: '2021-11-08'
-              dev_stats_url: https://openservicemesh.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#open-service-mesh-logos
               blog_url: https://openservicemesh.io/blog/
               mailing_list_url: https://groups.google.com/g/openservicemesh
@@ -4731,7 +4725,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2021-06-22'
-              dev_stats_url: https://smp.devstats.cncf.io/
+              dev_stats_url: https://servicemeshperformance.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#service-mesh-performance-logos
               slack_url: https://cloud-native.slack.com/messages/service-mesh-performance
               mailing_list_url: https://groups.google.com/a/smp-spec.io/g/community
@@ -5051,7 +5045,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/oracle
           - item:
             name: OrientDB
-            homepage_url: https://orientdb.com/why-orientdb/
+            homepage_url: https://orientdb.org/
             repo_url: https://github.com/orientechnologies/orientdb
             logo: orient-db.svg
             twitter: https://twitter.com/OrientDB
@@ -5383,7 +5377,6 @@ landscape:
             logo: weaviate.svg
             crunchbase: https://www.crunchbase.com/organization/semi-technologies
             extra:
-              artwork_url: https://www.semi.technology/playbooks/design/style-graphic-solutions.html
               stack_overflow_url: https://stackoverflow.com/questions/tagged/weaviate
               blog_url: https://medium.com/semi-technologies
               slack_url: https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw
@@ -5694,7 +5687,7 @@ landscape:
               dev_stats_url: https://pravega.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#pravega-logos
               blog_url: https://blog.pravega.io/
-              slack_url: https://pravega-slack-invite.herokuapp.com/
+              slack_url: https://pravega-io.slack.com/
               youtube_url: https://www.youtube.com/channel/UCiEkLCWdnjSpub76ZEZcdqw
               clomonitor_name: pravega
           - item:
@@ -5751,7 +5744,7 @@ landscape:
               accepted: '2019-08-28'
               annual_review_url: https://github.com/cncf/toc/pull/939
               annual_review_date: '2022-10-10'
-              dev_stats_url: https://strimzi.teststats.cncf.io/
+              dev_stats_url: https://strimzi.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#strimzi-logos
               mailing_list_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#strimzi-logos
               slack_url: https://cloud-native.slack.com/messages/strimzi
@@ -5851,7 +5844,7 @@ landscape:
               audits:
                 - date: '2022-08-23'
                   type: security
-                  url: https://backstage.io/blog/assets/22-08-23/X41-Backstage-Audit-2022.pdf
+                  url: https://backstage.io/blog/2022/08/23/backstage-security-audit/
                   vendor: X41 D-Sec
               summary_personas: Developers, SREs
               summary_tags: Developer Portals, IDP, Service Catalog, Observability
@@ -5875,7 +5868,7 @@ landscape:
               incubating: '2020-11-18'
               dev_stats_url: https://buildpacks.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#buildpacks-logos
-              slack_url: https://slack.buildpacks.io/
+              slack_url: https://slack.cncf.io/
               clomonitor_name: buildpacks
           - item:
             name: Carvel
@@ -5905,7 +5898,7 @@ landscape:
           - item:
             name: CloudARK KubePlus
             description: Build SaaS for your containerized applications
-            homepage_url: https://cloudark.io/helm-chart-as-a-service
+            homepage_url: https://cloudark.io/kubeplus
             repo_url: https://github.com/cloud-ark/kubeplus
             logo: cloudark-kubeplus.svg
             crunchbase: https://www.crunchbase.com/organization/cloudark
@@ -6423,7 +6416,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/raftt
           - item:
             name: sealer
-            homepage_url: https://sealer.cool
+            homepage_url: http://sealer.cool/
             project: sandbox
             repo_url: https://github.com/sealerio/sealer
             logo: sealer_logo.svg
@@ -6433,7 +6426,7 @@ landscape:
               accepted: '2022-04-26'
               annual_review_url: https://github.com/cncf/toc/pull/1041
               annual_review_date: '2023-04-26'
-              dev_stats_url: https://sealer.teststats.cncf.io/
+              dev_stats_url: https://sealer.devstats.cncf.io/
               slack_url: https://kubernetes.slack.com/messages/sealer
               clomonitor_name: sealer
           - item:
@@ -6500,7 +6493,6 @@ landscape:
               annual_review_date: '2022-07-08'
               dev_stats_url: https://telepresence.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#telepresence-logos
-              slack_url: https://d6e.co/slack
               chat_channel: '#telepresence'
               summary_personas: Developers, Platform Engineers
               summary_tags: debug,develop,api,testing,remocal
@@ -6651,7 +6643,6 @@ landscape:
             extra:
               accepted: '2019-03-18'
               archived: '2022-10-19'
-              dev_stats_url: https://brigade.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#brigade-logos
               slack_url: https://kubernetes.slack.com/messages/C87MF1RFD
           - item:
@@ -6842,7 +6833,7 @@ landscape:
             description: >-
               An app-centric abstraction framework over K8s and an enterprise platform for accelerating deployments to multi-cloud Kubernetes. Offers
               self-service app deployments, container sprawl management across clusters, and DevSecOps.
-            homepage_url: https://www.hyscale.io
+            homepage_url: https://github.com/hyscale/hyscale#readme
             repo_url: https://github.com/hyscale/hyscale
             logo: hyscale.svg
             crunchbase: https://www.crunchbase.com/organization/hyscale
@@ -7239,7 +7230,7 @@ landscape:
             description: >-
               Daocloud helps you provide a reliable and consistent basic support environment to meet the high SLA requirements of enterprise critical
               applications.
-            homepage_url: https://www.daocloud.io/dce
+            homepage_url: https://www.daocloud.io/en/
             logo: daocloud.svg
             crunchbase: https://www.crunchbase.com/organization/daocloud
           - item:
@@ -7316,7 +7307,7 @@ landscape:
           - item:
             name: HarmonyCloud Container Platform
             description: HarmonyCloud Container Platform is an Enterprise Platform-as-a-Service based on Kubernetes.
-            homepage_url: http://harmonycloud.cn/products/rongqiyun/
+            homepage_url: https://harmonycloud.cn/
             logo: harmonycloud.svg
             crunchbase: https://www.crunchbase.com/organization/harmony-cloud
           - item:
@@ -7332,7 +7323,7 @@ landscape:
             description: >-
               JDOS is Jingdong Datacenter OS for automated management of shared container clusters and containerized applications in a scalable and elastic
               manner. The key systems include ContainerFS, ContainerDNS and ContainerLB.
-            homepage_url: http://tig.jd.com/en/products/jdos
+            homepage_url: https://global.jd.com/
             logo: jd.com.svg
             crunchbase: https://www.crunchbase.com/organization/jd-cloud
           - item:
@@ -7872,7 +7863,7 @@ landscape:
               The plusserver Kubernetes Engine (PSKE) based on Gardener reduces the complexity in managing multi-cloud environments and enables companies to
               orchestrate their containers and cloud-native applications across a variety of platforms such as plusserver’s pluscloud open or hyperscalers such
               as AWS, either by mouseclick or via an API.
-            homepage_url: https://www.plusserver.com/en/produkte/managed-kubernetes
+            homepage_url: https://www.plusserver.com/en/product/managed-kubernetes/
             logo: plusserver.svg
             crunchbase: https://www.crunchbase.com/organization/plusserver
           - item:
@@ -8412,7 +8403,7 @@ landscape:
           - item:
             name: Sigma
             description: Sigma is a serverless application developer tool; a cloud IDE, which helps you rapidly build, test and deploy serverless applications.
-            homepage_url: https://www.slappforge.com/sigma
+            homepage_url: https://slappforge.github.io/sigma/
             logo: slappforge-sigma.svg
             twitter: https://twitter.com/SigmaIDE
             crunchbase: https://www.crunchbase.com/organization/slappforge
@@ -8560,7 +8551,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/sst-c030
           - item:
             name: Stateful Functions
-            homepage_url: https://statefun.io
+            homepage_url: https://nightlies.apache.org/flink/flink-statefun-docs-master/
             repo_url: https://github.com/apache/flink-statefun
             logo: statefun.svg
             twitter: https://twitter.com/statefun_io
@@ -8746,7 +8737,7 @@ landscape:
           - item:
             name: Twilio Functions
             description: A serverless environment to build and run your Twilio code so you can get to production faster.
-            homepage_url: https://www.twilio.com/runtime/build
+            homepage_url: https://www.twilio.com/docs/serverless/functions-assets/functions
             logo: twilio-functions.svg
             crunchbase: https://www.crunchbase.com/organization/twilio
           - item:
@@ -8858,7 +8849,7 @@ landscape:
               summary_intro_url: https://knative.dev/docs/getting-started/
           - item:
             name: Knix
-            homepage_url: https://knix.io/
+            homepage_url: https://github.com/knix-microfunctions/knix?tab=readme-ov-file
             repo_url: https://github.com/knix-microfunctions/knix
             logo: knix.svg
             twitter: https://twitter.com/BellLabs
@@ -9104,12 +9095,12 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/dynatrace-software
           - item:
             name: Epsagon
-            homepage_url: https://www.epsagon.com/
+            homepage_url: https://github.com/epsagon
             logo: epsagon.svg
             crunchbase: https://www.crunchbase.com/organization/epsagon
           - item:
             name: Falcon
-            homepage_url: https://open-falcon.com
+            homepage_url: https://github.com/open-falcon/falcon-plus
             repo_url: https://github.com/open-falcon/falcon-plus
             logo: falcon.svg
             twitter: null
@@ -9405,14 +9396,14 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/new-relic
           - item:
             name: NexClipper
-            homepage_url: https://www.nexclipper.io/
+            homepage_url: https://github.com/NexClipper/NexClipper?tab=readme-ov-file
             repo_url: https://github.com/NexClipper/NexClipper
             logo: nexclipper.svg
             twitter: https://twitter.com/nexclipper
             crunchbase: https://www.crunchbase.com/organization/nexcloud
           - item:
             name: Nightingale
-            homepage_url: http://n9e.didiyun.com
+            homepage_url: https://n9e.github.io/
             repo_url: https://github.com/didi/nightingale
             logo: nightingale.svg
             crunchbase: https://www.crunchbase.com/organization/didi
@@ -9449,7 +9440,7 @@ landscape:
           - item:
             name: Opstrace
             description: Secure Open Source Observability Deployed in your own Network
-            homepage_url: https://www.opstrace.com/
+            homepage_url: https://github.com/opstrace/opstrace
             repo_url: https://github.com/opstrace/opstrace
             logo: opstrace.svg
             crunchbase: https://www.crunchbase.com/organization/opstrace
@@ -9567,7 +9558,7 @@ landscape:
           - item:
             name: Sidekick
             description: Collect traces, exception stacks and generate logs on-demand without stopping & redeploying your applications.
-            homepage_url: https://www.runsidekick.com/
+            homepage_url: https://github.com/runsidekick/sidekick
             repo_url: https://github.com/runsidekick/sidekick
             logo: sidekick.svg
             open_source: true
@@ -9868,7 +9859,7 @@ landscape:
           - item:
             name: Loggie
             description: Loggie is a lightweight, high-performance, cloud-native log collection agent and aggregator based on Golang.
-            homepage_url: https://loggie-io.github.io/
+            homepage_url: https://github.com/loggie-io/loggie
             repo_url: https://github.com/loggie-io/loggie
             logo: loggie.svg
             crunchbase: https://www.crunchbase.com/organization/netease-com
@@ -10091,7 +10082,6 @@ landscape:
             extra:
               accepted: '2016-10-11'
               incubating: '2016-10-11'
-              dev_stats_url: https://opentracing.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#opentracing-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/opentracing
               blog_url: https://medium.com/opentracing
@@ -10100,7 +10090,7 @@ landscape:
               specification: true
           - item:
             name: Pinpoint
-            homepage_url: https://naver.github.io/pinpoint/
+            homepage_url: https://pinpoint-apm.github.io/pinpoint/
             repo_url: https://github.com/pinpoint-apm/pinpoint
             logo: pinpoint.svg
             crunchbase: https://www.crunchbase.com/organization/pinpoint-282b
@@ -10132,7 +10122,7 @@ landscape:
           - item:
             name: Teletrace
             description: Teletrace is an open-source troubleshooting tool based on traces, designed for cloud-native distributed applications.
-            homepage_url: https://docs.teletrace.io/
+            homepage_url: https://github.com/teletrace/teletrace?tab=readme-ov-file
             repo_url: https://github.com/teletrace/teletrace
             logo: teletrace.svg
             crunchbase: https://www.crunchbase.com/organization/cisco
@@ -10550,7 +10540,7 @@ landscape:
           - item:
             name: ATIX (KCSP)
             description: ATIX plans, builds & runs Kubernetes clusters. We provide operational support and teach companies how to profit from using Kubernetes.
-            homepage_url: https://atix.de/en/solutions/it-infrastructure/container-platforms/kubernetes
+            homepage_url: https://atix.de/en/services/technologies/container-platforms/kubernetes/
             logo: atix-ag.svg
             crunchbase: https://www.crunchbase.com/organization/atix
           - item:
@@ -10566,7 +10556,7 @@ landscape:
             description: >-
               b-nova is a Swiss consulting company based in Basel that is specialised in enabling and crafting innovative cloud driven solutions and efficient
               developer experiences using Kubernetes, cloud native and serverless technologies.
-            homepage_url: https://b-nova.com/en/home/kompetenzen/kubernetes
+            homepage_url: https://b-nova.com/home/
             logo: b-nova.svg
             crunchbase: https://www.crunchbase.com/organization/b-nova-schweiz-gmbh
           - item:
@@ -10626,7 +10616,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/blue-sentry
           - item:
             name: BoCloud (KCSP)
-            homepage_url: http://bocloud.com.cn/
+            homepage_url: https://github.com/BoCloud
             logo: bo-cloud-kcsp.svg
             crunchbase: https://www.crunchbase.com/organization/bocloud
           - item:
@@ -10989,7 +10979,7 @@ landscape:
               organisations. Our team of CNCF Certified Kubernetes Administrators (CKAs) are able to quickly and efficiently move from requirements to
               implementation, using industry standard automation tools to deliver a functional proof-of-concept platform that allows customers to get running
               faster, without having to dedicate existing staff time.
-            homepage_url: https://www.evolvere-tech.co.uk/kubernetes
+            homepage_url: https://www.evolvere-tech.co.uk/
             logo: evolvere.svg
             crunchbase: https://www.crunchbase.com/organization/evolvere-technologies
           - item:
@@ -11201,7 +11191,7 @@ landscape:
               Inspur Cloud provides you with one-stop services from consulting to operation and maintenance. With cloud delivery capabilities throughout the
               whole service chain, we provide six kinds of professional services including resource planning, cloud solution, security assurance, business
               migration, data integration and application innovation.
-            homepage_url: https://cloud.inspur.com/snipet/1023.html
+            homepage_url: https://cloud.inspur.com/
             logo: inspur.svg
             crunchbase: https://www.crunchbase.com/organization/inspur
           - item:
@@ -11209,7 +11199,7 @@ landscape:
             description: >-
               We provide customers with cloud native technical consulting and recommend the optimal cloud solution. We also provide overall solutions based on
               Docker and Kubernetes container platform technology.
-            homepage_url: https://www.isoftstone.com/htmlsen/dashujuchanyefuwu/index.html
+            homepage_url: https://www.isoftstone.com/
             logo: isoftstone.svg
             crunchbase: https://www.crunchbase.com/organization/isoftstone
           - item:
@@ -11231,7 +11221,7 @@ landscape:
           - item:
             name: KBSYS (KCSP)
             description: KBSYS provides Kubernetes consulting, training, and support services to companies preparing for a cloud transformation.
-            homepage_url: http://kb-sys.co.kr/index
+            homepage_url: http://kb-sys.co.kr/ko/index
             logo: kbsys.svg
             crunchbase: https://www.crunchbase.com/organization/kbsys
             joined: '2021-01-23'
@@ -11334,7 +11324,7 @@ landscape:
           - item:
             name: LSD Open (KCSP)
             description: Fully managed and engineered cloud native accelerator, leveraging a foundation of containerization, Kubernetes and open source technologies
-            homepage_url: https://lsdopen.io/kubernetes-services/
+            homepage_url: https://lsdopen.io/managed-kubernetes/
             logo: LSD-OPEN.svg
             crunchbase: https://www.crunchbase.com/organization/lsd-open
           - item:
@@ -11788,7 +11778,7 @@ landscape:
             description: >-
               SoKube is a Swiss based company that helps companies making their digital transition to the world of containers and Kubernetes orchestration, with
               a strong focus on Agility and DevSecOps lifecycle.
-            homepage_url: https://en.sokube.ch/projects
+            homepage_url: https://www.sokube.io/en/home
             logo: sokube.svg
             crunchbase: https://www.crunchbase.com/organization/sokube
           - item:
@@ -11832,7 +11822,7 @@ landscape:
             description: >-
               Steamhaus are AWS cloud native experts, specialising in designing, building and operating containers and serverless platforms. We help startups
               scale fast and securely, and we help enterprises accelerate and derisk modernisation and transformation.
-            homepage_url: https://www.steamhaus.co.uk/kubernetes/
+            homepage_url: https://www.steamhaus.co.uk/
             logo: steamhaus.svg
             crunchbase: https://www.crunchbase.com/organization/steamhaus
           - item:
@@ -11863,7 +11853,7 @@ landscape:
             description: >-
               Sup-Info is experienced in Kubernetes-based cloud building，operating，consulting，and training. We also provide professional services for
               cloud-related open source software.
-            homepage_url: http://www.sup-info.com.cn/NewsClass.aspx?ClassID=19
+            homepage_url: http://www.sup-info.com.cn/
             logo: sup-info.svg
             crunchbase: https://www.crunchbase.com/organization/beijing-sup-info-information-technology-co-ltd
           - item:
@@ -12072,7 +12062,7 @@ landscape:
           - item:
             name: WhaTap (KCSP)
             description: Whatap Labs provides SaaS-based Kubernetes, APM ,DB monitoring and support application optimization in Kubernetes.
-            homepage_url: https://www.whatap.io/en/container-monitoring/kubernetes/
+            homepage_url: https://www.whatap.io/en
             logo: whatap-labs.svg
             crunchbase: https://www.crunchbase.com/organization/whatap-labs
           - item:
@@ -12096,7 +12086,7 @@ landscape:
           - item:
             name: WOQU Tech (KCSP)
             description: WOQU Tech provides best practices and services for relational and non-relational database clusters in Kubernetes infrastructure.
-            homepage_url: http://www.woqutech.com/k8s.php
+            homepage_url: https://www.woqutech.com/
             logo: woqutech.svg
             crunchbase: https://www.crunchbase.com/organization/woqu-technology-co-ltd
           - item:
@@ -12131,7 +12121,7 @@ landscape:
           - item:
             name: YLD (KCSP)
             description: We modernise both practices and software. Applying expertise in a range of CNCF technologies and an inherent culture of innovation.
-            homepage_url: https://www.yld.io/speciality/kubernetes/
+            homepage_url: https://www.yld.io/
             logo: yld-kcsp.svg
             crunchbase: https://www.crunchbase.com/organization/yld
           - item:
@@ -12141,7 +12131,7 @@ landscape:
               partner to manufacturing & retail companies in the DACH region, and together develop & implement long-term digital strategies to help them remain
               competitive in an increasingly digital world. As a KCSP partner, we have validated expertise helping organisations successfully adopt Kubernetes.
               We offer Kubernetes support, consulting, professional services and training for clients embarking on their Kubernetes journey.
-            homepage_url: https://en.zoi.tech/kubernetes
+            homepage_url: https://www.zoi.tech/
             logo: zoi.svg
             crunchbase: https://www.crunchbase.com/organization/zoi-1e34
           - item:
@@ -12149,7 +12139,7 @@ landscape:
             description: >-
               ZStack enables customers on their Kubernetes journey, helps enterprises focus on their applications rather than managing IT-infrastructure, and
               offers full life-cycle services including training, consulting, deployment, and pipeline to accelerate their digital transformation.
-            homepage_url: https://www.zstack-cloud.com/intl/support/center/services/
+            homepage_url: https://www.zstack-cloud.com/
             logo: zstack.svg
             crunchbase: https://www.crunchbase.com/organization/zstack
           - item:
@@ -12245,7 +12235,7 @@ landscape:
             description: >-
               CINQ ICT is a consultancy agency based in the Netherlands, working for enterprise level companies to design, build and manage container platforms,
               CI/CD pipelines, cloud platforms and software solutions in public cloud and multi/hybrid environments.
-            homepage_url: https://www.cinqict.nl/kubernetes/trainingen
+            homepage_url: https://www.cinqict.nl/
             logo: cinq-ict.svg
             crunchbase: https://www.crunchbase.com/organization/cinq
           - item:
@@ -12325,7 +12315,7 @@ landscape:
               DaoCloud is an innovative leader in the cloud-native field, being committed to creating an open Cloud OS which enables enterprises to easily carry
               out digital transformation.  DaoCloud provides excellent courses of KCNA, CKAD, CKA and CKS, with the accumulation of cloud-native technology and
               examination. These courses can train technical experts in digital transformation.
-            homepage_url: https://www.daocloud.io/training
+            homepage_url: https://www.daocloud.io/
             logo: daocloud.svg
             crunchbase: https://www.crunchbase.com/organization/daocloud
           - item:
@@ -12428,7 +12418,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/huawei
           - item:
             name: INSPUR (KTP)
-            homepage_url: https://en.inspur.com
+            homepage_url: https://www.inspur.com/
             logo: inspur.svg
             crunchbase: https://www.crunchbase.com/organization/inspur
           - item:
@@ -12534,7 +12524,7 @@ landscape:
           - item:
             name: Shinesoft (KTP)
             description: We provide design, development and tech support include; Cloud/Cluster, Network, Server, Security, Monitoring, Data analysis, and AI/IoT
-            homepage_url: https://www.shinesoft.co.jp/business/#training
+            homepage_url: https://shinesoft.co.jp/business/
             logo: shinesoft.svg
             crunchbase: https://www.crunchbase.com/organization/shinesoft-co-ltd
           - item:
@@ -12553,7 +12543,7 @@ landscape:
             description: >-
               SoKube is pure consulting company that help companies entering the world of Containers & Kubernetes, using a comprehensive SDLC approach from Dev
               to Production, and using best practices coming from Agile, CI/CD, DevSecOps, SRE, GitOps.
-            homepage_url: https://en.sokube.ch/training
+            homepage_url: https://www.sokube.io/en/services/training
             logo: sokube.svg
             crunchbase: https://www.crunchbase.com/organization/sokube
             extra:
@@ -13114,7 +13104,7 @@ landscape:
             joined: '2019-03-01'
           - item:
             name: Akuity (member)
-            homepage_url: https://www.akuity.io/
+            homepage_url: https://akuity.io/
             logo: akuity.svg
             crunchbase: https://www.crunchbase.com/organization/akuity
             joined: '2022-01-01'
@@ -13499,7 +13489,7 @@ landscape:
             joined: '2020-03-01'
           - item:
             name: BoCloud (member)
-            homepage_url: http://www.bocloud.com.cn/en/index.html
+            homepage_url: https://github.com/BoCloud
             logo: bo-cloud-member.svg
             crunchbase: https://www.crunchbase.com/organization/bocloud
             joined: '2017-10-01'
@@ -14296,7 +14286,7 @@ landscape:
             joined: '2022-11-01'
           - item:
             name: Evonem (member)
-            homepage_url: https://www.evonem.com/
+            homepage_url: https://evonem.com/
             logo: evonem.svg
             crunchbase: https://www.crunchbase.com/organization/evonem
             joined: '2023-04-01'
@@ -14903,7 +14893,7 @@ landscape:
             joined: '2023-05-01'
           - item:
             name: Lablup (member)
-            homepage_url: https://www.lablup.com/home
+            homepage_url: https://www.lablup.com/
             logo: lablup.svg
             crunchbase: https://www.crunchbase.com/organization/lablup
             joined: '2020-11-01'
@@ -15235,7 +15225,7 @@ landscape:
             joined: '2023-11-01'
           - item:
             name: ndustrial (member)
-            homepage_url: https://www.ndustrial.io/
+            homepage_url: https://ndustrial.io/
             logo: ndustrial.svg
             crunchbase: https://www.crunchbase.com/organization/ndustrial-io
             joined: '2021-07-01'
@@ -15463,7 +15453,7 @@ landscape:
             joined: '2020-10-01'
           - item:
             name: Open Source Consulting (member)
-            homepage_url: https://www.osci.kr/main.php
+            homepage_url: https://www.osci.kr/
             logo: open-source-consulting.svg
             crunchbase: https://www.crunchbase.com/organization/open-source-consulting
             joined: '2020-04-01'           
@@ -16037,7 +16027,7 @@ landscape:
             joined: '2019-10-01'
           - item:
             name: Services4-IT (member)
-            homepage_url: https://www.services4-it.eu/index
+            homepage_url: https://www.services4-it.eu/
             logo: services4-it.svg
             crunchbase: https://www.crunchbase.com/organization/services4-it
             joined: '2021-10-01'
@@ -16159,7 +16149,7 @@ landscape:
             joined: '2021-07-01'
           - item:
             name: SoKube (member)
-            homepage_url: https://en.sokube.ch/
+            homepage_url: https://www.sokube.io/
             logo: sokube.svg
             crunchbase: https://www.crunchbase.com/organization/sokube
             joined: '2020-06-01'
@@ -16219,7 +16209,7 @@ landscape:
             joined: '2022-04-01'
           - item:
             name: SphereEx (member)
-            homepage_url: https://www.sphere-ex.com/en/
+            homepage_url: https://sphere-ex.com/
             logo: sphereex.svg
             crunchbase: https://www.crunchbase.com/organization/sphereex
             joined: '2022-05-01'
@@ -16887,7 +16877,7 @@ landscape:
             joined: '2021-06-01'
           - item:
             name: Zelarsoft (member)
-            homepage_url: https://www.zelarsoft.com/
+            homepage_url: https://zelarsoft.com/
             logo: zelar.svg
             crunchbase: https://www.crunchbase.com/organization/zelarsoft
             joined: '2022-04-01'
@@ -16993,7 +16983,7 @@ landscape:
             joined: '2019-06-01'
           - item:
             name: MITRE (member)
-            homepage_url: https://https://www.mitre.org/
+            homepage_url: https://www.mitre.org/
             logo: mitre_logo.svg
             crunchbase: https://www.crunchbase.com/organization/mitre
             joined: '2021-03-01'
@@ -17071,7 +17061,7 @@ landscape:
         items:
           - item:
             name: 4intelligence (supporter)
-            homepage_url: https://4intelligence.com.br/mvpe/#/Main
+            homepage_url: https://4intelligence.ai/
             logo: 4intelligence.svg
             crunchbase: https://www.crunchbase.com/organization/4intelligence
             joined: '2021-10-01'
@@ -18039,7 +18029,7 @@ landscape:
             allow_duplicate_repo: true
           - item:
             name: Kube-scheduler
-            homepage_url: https://kubernetes.io/docs/reference/scheduling/kube-scheduler/
+            homepage_url: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
             repo_url: https://github.com/kubernetes-sigs/scheduler-plugins
             logo: kubernetes.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
@@ -18274,7 +18264,7 @@ landscape:
               clomonitor_name: meshery
           - item:
             name: OpenYurt (Wasm)
-            homepage_url: https://openyurt.io/en-us/
+            homepage_url: https://openyurt.io/
             repo_url: https://github.com/openyurtio/openyurt
             logo: openyurt.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation


### PR DESCRIPTION
This addresses #3641 by fixing broken links in landscape.yml from [this report](https://docs.google.com/spreadsheets/d/1ST806KAE9Cj9fe2PJ0-h0ciBkDdUd0khwmJrhSxva2g/edit#gid=1105913198). It's important to fix these as they show up on the landscape site, cncf.io and all other downstream sites that consume landscape.yml. Broken links can contribute to lowering our page rank in Google in addition to degrading the user experience.

Some of these broken links are for projects and companies that no longer appear to exist. In such cases when the main website is also down, I swapped in the github repo or linkedin url for the project homepage. I suggest we delete those entries from landscape.yml if they are truly dead and not coming back but I'm not sure if this is the correct practice. I can provide a list of such entries for a future PR if we agree on this.