### PR TITLE
Update Keptn repo URL and Slack URL

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6930,7 +6930,7 @@ landscape:
               dev_stats_url: https://keptn.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#keptn-logos
               youtube_url: https://www.youtube.com/channel/UCHMn9HyAMeb81bRlaOuZyuQ
-              slack_url: https://cloud-native.slack.com/archives/C017GAX90GM
+              slack_url: https://cloud-native.slack.com/messages/keptn/
               clomonitor_name: keptn
               summary_personas: SREs, DevOps & Platform Engineers, Architects, Developers
               summary_tags: Application, Container, Microservices, Security, GitOps, Kubernetes, Helm, Observability, CI/CD, SLI, SLO, SLA, Observability

--- a/landscape.yml
+++ b/landscape.yml
@@ -6920,7 +6920,7 @@ landscape:
               applications.
             homepage_url: https://www.keptn.sh
             project: incubating
-            repo_url: https://github.com/keptn/keptn
+            repo_url: https://github.com/keptn/lifecycle-toolkit
             logo: keptn.svg
             twitter: https://twitter.com/keptnproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
@@ -6930,7 +6930,7 @@ landscape:
               dev_stats_url: https://keptn.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#keptn-logos
               youtube_url: https://www.youtube.com/channel/UCHMn9HyAMeb81bRlaOuZyuQ
-              slack_url: https://slack.keptn.sh/
+              slack_url: https://cloud-native.slack.com/archives/C017GAX90GM
               clomonitor_name: keptn
               summary_personas: SREs, DevOps & Platform Engineers, Architects, Developers
               summary_tags: Application, Container, Microservices, Security, GitOps, Kubernetes, Helm, Observability, CI/CD, SLI, SLO, SLA, Observability


### PR DESCRIPTION
### This PR
- updates the repo URL for the Keptn project from the old keptn repo to the new lifecycle-toolkit
- updates the slack URL for the Keptn project since we shut down our own slack workspace in favor of the CNCF one

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
