### PR TITLE
Removed Endress+Hauser crunchbase entry

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -17091,7 +17091,7 @@ landscape:
             name: Endress+Hauser (supporter)
             homepage_url: https://www.endress.com
             logo: endress+hauser.svg
-            crunchbase: https://www.crunchbase.com/organization/endress-and-hauser
+            description: Endress+Hauser is a global leader in measurement and automation technology for process and laboratory applications.
             joined: '2024-01-01'
           - item:
             name: Entegral (supporter)


### PR DESCRIPTION
Removed Endress+Hauser crunchbase entry and added manual description

Dear CNCF Team, as contact for Endress+Hauser I would like to remove the currently used Crunchbase entry and switch to a static description. On Crunchbase only single Endress+Hauser entities are represented, not the whole group.

If we in the future are able to provide a single group-wide entry we will switch to this Crunchbase entry. For now however, we would like to remove it.
