### PR TITLE
Update harbor TAG label to match README requiements

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -593,8 +593,7 @@ landscape:
               accepted: '2018-07-31'
               incubating: '2018-11-14'
               graduated: '2020-06-15'
-              cncf_tags:
-                - https://github.com/cncf/tag-app-delivery
+              tag: app-delivery
               dev_stats_url: https://harbor.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#harbor-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/harbor


### PR DESCRIPTION
Updating Habor's TAG label to match the requirement of the [README](https://github.com/cncf/landscape?tab=readme-ov-file#technical-advisory-groups-tag)

Once this PR merge and it work as expected, a follow-up PR would be made to update the remaining 22 instances of the `cncf_tags:` label.

After that work will be started to ensure all project have the correct TAG assigned in the "extras" field.


