### PR TITLE
Update TAG labels to match README requirements

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -4219,7 +4219,7 @@ landscape:
               accepted: '2017-09-13'
               incubating: '2017-09-13'
               graduated: '2018-11-28'
-              tags: tag-network
+              tag: network
               dev_stats_url: https://envoy.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#envoy-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/envoyproxy
@@ -4645,7 +4645,7 @@ landscape:
               accepted: '2022-09-30'
               incubating: '2022-09-30'
               graduated: '2023-07-12'
-              tags: tag-network
+              tag: network
               dev_stats_url: https://istio.devstats.cncf.io/
               stack_overflow_url: https://stackoverflow.com/questions/tagged/istio
               blog_url: https://istio.io/blog/

--- a/landscape.yml
+++ b/landscape.yml
@@ -593,8 +593,7 @@ landscape:
               accepted: '2018-07-31'
               incubating: '2018-11-14'
               graduated: '2020-06-15'
-              cncf_tags:
-                - https://github.com/cncf/tag-app-delivery
+              tag: app-delivery
               dev_stats_url: https://harbor.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#harbor-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/harbor
@@ -1449,8 +1448,7 @@ landscape:
               accepted: '2018-03-29'
               incubating: '2019-04-02'
               graduated: '2021-01-29'
-              cncf_tags:
-                - https://github.com/cncf/tag-security
+              tag: security
               dev_stats_url: https://opa.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#opa-logos
               blog_url: https://blog.openpolicyagent.org/
@@ -1793,8 +1791,7 @@ landscape:
               accepted: '2017-10-24'
               incubating: '2017-10-24'
               graduated: '2019-12-18'
-              cncf_tags:
-                - https://github.com/cncf/tag-security
+              tag: security
               dev_stats_url: https://tuf.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#tuf-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/the-update-framework
@@ -1955,8 +1952,7 @@ landscape:
               accepted: '2018-03-29'
               incubating: '2020-06-22'
               graduated: '2022-08-23'
-              cncf_tags:
-                - https://github.com/cncf/tag-security
+              tag: security
               dev_stats_url: https://spiffe.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#spiffe-logos
               blog_url: https://blog.spiffe.io/
@@ -2046,8 +2042,7 @@ landscape:
               accepted: '2018-03-29'
               incubating: '2020-06-22'
               graduated: '2022-08-22'
-              cncf_tags:
-                - https://github.com/cncf/tag-security
+              tag: security
               dev_stats_url: https://spire.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#spire-logos
               slack_url: https://slack.spiffe.io/
@@ -2591,8 +2586,7 @@ landscape:
               accepted: '2018-01-29'
               incubating: '2018-09-25'
               graduated: '2020-10-07'
-              cncf_tags:
-                - https://github.com/cncf/tag-storage
+              tag: storage
               dev_stats_url: https://rook.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#rook-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/rook
@@ -2771,8 +2765,7 @@ landscape:
               accepted: '2017-03-29'
               incubating: '2017-03-29'
               graduated: '2019-02-28'
-              cncf_tags:
-                - https://github.com/cncf/tag-runtime
+              tag: runtime
               dev_stats_url: https://containerd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#containerd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/containerd
@@ -2796,8 +2789,7 @@ landscape:
               accepted: '2019-04-08'
               incubating: '2019-04-08'
               graduated: '2023-07-19'
-              cncf_tags:
-                - https://github.com/cncf/tag-runtime
+              tag: runtime
               dev_stats_url: https://crio.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#cri-o-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/cri-o
@@ -3693,8 +3685,7 @@ landscape:
               accepted: '2016-03-10'
               incubating: '2016-03-10'
               graduated: '2018-03-06'
-              cncf_tags:
-                - https://github.com/cncf/tag-runtime
+              tag: runtime
               dev_stats_url: https://k8s.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#kubernetes-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/kubernetes
@@ -3926,8 +3917,7 @@ landscape:
               accepted: '2017-02-27'
               incubating: '2018-02-26'
               graduated: '2019-01-24'
-              cncf_tags:
-                - https://github.com/cncf/tag-network
+              tag: network
               dev_stats_url: https://coredns.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#coredns-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/coredns
@@ -3953,8 +3943,7 @@ landscape:
               accepted: '2018-12-11'
               incubating: '2018-12-11'
               graduated: '2020-11-24'
-              cncf_tags:
-                - https://github.com/cncf/tag-storage
+              tag: storage
               dev_stats_url: https://etcd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#etcd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/etcd
@@ -4230,8 +4219,7 @@ landscape:
               accepted: '2017-09-13'
               incubating: '2017-09-13'
               graduated: '2018-11-28'
-              cncf_tags:
-                - https://github.com/cncf/tag-network
+              tags: tag-network
               dev_stats_url: https://envoy.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#envoy-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/envoyproxy
@@ -4657,8 +4645,7 @@ landscape:
               accepted: '2022-09-30'
               incubating: '2022-09-30'
               graduated: '2023-07-12'
-              cncf_tags:
-                - https://github.com/cncf/tag-network
+              tags: tag-network
               dev_stats_url: https://istio.devstats.cncf.io/
               stack_overflow_url: https://stackoverflow.com/questions/tagged/istio
               blog_url: https://istio.io/blog/
@@ -4721,8 +4708,7 @@ landscape:
               accepted: '2017-01-23'
               incubating: '2018-04-06'
               graduated: '2021-07-28'
-              cncf_tags:
-                - https://github.com/cncf/tag-network
+              tag: network
               dev_stats_url: https://linkerd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#linkerd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/linkerd
@@ -5366,8 +5352,7 @@ landscape:
               accepted: '2018-08-28'
               incubating: '2018-08-28'
               graduated: '2020-09-02'
-              cncf_tags:
-                - https://github.com/cncf/tag-storage
+              tag: storage
               dev_stats_url: https://tikv.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#tikv-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/tikv
@@ -5473,8 +5458,7 @@ landscape:
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#vitess-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/vitess
               blog_url: https://vitess.io/blog/
-              cncf_tags:
-                - https://github.com/cncf/tag-storage
+              tag: storage
               mailing_list_url: https://lists.cncf.io/g/cncf-vitess-users
               summary_personas: Infrastructure teams
               summary_tags: Scalable, reliable, MySQL, distributed, cloud-native, kubernetes, cloud, database
@@ -6248,8 +6232,7 @@ landscape:
               accepted: '2018-06-01'
               incubating: '2018-06-01'
               graduated: '2020-05-01'
-              cncf_tags:
-                - https://github.com/cncf/tag-app-delivery
+              tag: app-delivery
               dev_stats_url: https://helm.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/main/examples/graduated.md
               slack_url: https://slack.k8s.io
@@ -6808,8 +6791,7 @@ landscape:
               accepted: '2020-03-26'
               incubating: '2020-03-26'
               graduated: '2022-12-06'
-              cncf_tags:
-                - https://github.com/cncf/tag-app-delivery
+              tag: app-delivery
               dev_stats_url: https://argo.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/argo
               stack_overflow_url: https://stackoverflow.com/questions/tagged/argoproj+or+argo
@@ -6982,8 +6964,7 @@ landscape:
               accepted: '2019-07-15'
               incubating: '2021-03-12'
               graduated: '2022-11-30'
-              cncf_tags:
-                - https://github.com/cncf/tag-app-delivery
+              tag: app-delivery
               dev_stats_url: https://flux.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#flux-logos
               blog_url: https://fluxcd.io/blog/
@@ -9734,8 +9715,7 @@ landscape:
               accepted: '2016-11-08'
               incubating: '2016-11-08'
               graduated: '2019-04-11'
-              cncf_tags:
-                - https://github.com/cncf/tag-observability
+              tag: observability
               dev_stats_url: https://fluentd.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#fluentd-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/fluentd
@@ -9939,8 +9919,7 @@ landscape:
               accepted: '2017-09-13'
               incubating: '2017-09-13'
               graduated: '2019-10-31'
-              cncf_tags:
-                - https://github.com/cncf/tag-observability
+              tag: observability
               dev_stats_url: https://jaeger.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#jaeger-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/jaeger
@@ -10061,8 +10040,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               accepted: '2023-09-19'
-              cncf_tags:
-                - https://github.com/cncf/tag-observability
+              tag: observability
               dev_stats_url: https://loggingoperator.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/main/examples/sandbox.md/#logging-operator-logos
               clomonitor_name: logging-operator
@@ -10342,8 +10320,7 @@ landscape:
               accepted: '2016-05-09'
               incubating: '2016-05-09'
               graduated: '2018-08-09'
-              cncf_tags:
-                - https://github.com/cncf/tag-observability
+              tag: observability
               dev_stats_url: https://prometheus.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#prometheus-logos
               stack_overflow_url: https://stackoverflow.com/questions/tagged/prometheus


### PR DESCRIPTION
Confirmed the `tag:` function work as expected in #3845 

This PR clean up all `cncf_tag` labels in the file