### PR TITLE
Update landscape.yml for Microcks extra missing field

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6591,6 +6591,7 @@ landscape:
               summary_integrations: >-
                 Keycloak, Operator framework, Helm, Backstage.io, Tekton, CloudEvents, Prometheus, OpenTelemetry, Docker, Podman, Testcontainers
               summary_intro_url: https://www.youtube.com/watch?v=E8rjUwznO-Q
+              clomonitor_name: microcks
           - item:
             name: mirrord
             description: >-


### PR DESCRIPTION
I am adding "clomonitor_name: microcks" to Microcks extra fields. 
Because it is mandatory to pass the "Summary Table" check.
