### PR TITLE
Add TAG Network project tags to landscape.yml file

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3090,6 +3090,7 @@ landscape:
               summary_integration: Kubernetes, Prometheus, OpenTelemetry, Envoy, Istio, Grafana, cert-manager, SPIFFE
               summary_intro_url: ''
               clomonitor_name: cilium
+              tag: network
               audits:
                 - date: '2023-02-13'
                   type: security
@@ -3112,6 +3113,7 @@ landscape:
               annual_review_date: '2022-06-21'
               dev_stats_url: https://cnigenie.devstats.cncf.io/
               clomonitor_name: cni-genie
+              tag: network
           - item:
             name: Container Network Interface (CNI)
             homepage_url: https://www.cni.dev/
@@ -3129,6 +3131,7 @@ landscape:
               slack_url: https://containernetworking.slack.com
               specification: true
               clomonitor_name: cni
+              tag: network
           - item:
             name: Cumulus
             homepage_url: https://www.nvidia.com/en-us/networking/ethernet-switching
@@ -3246,6 +3249,7 @@ landscape:
               mailing_list_url: https://groups.google.com/forum/#!forum/networkservicemesh
               slack_url: https://cloud-native.slack.com/messages/CHQNNUPN1/details/
               clomonitor_name: network-service-mesh
+              tag: network
           - item:
             name: Nuage Networks
             homepage_url: https://www.nuagenetworks.net/
@@ -4177,6 +4181,7 @@ landscape:
               youtube_url: https://www.youtube.com/channel/UCrnk1HWelWnYtF78YZX80fg
               gitter_url: https://gitter.im/grpc/grpc
               clomonitor_name: grpc
+              tag: network
               audits:
                 - date: '2019-10-29'
                   type: security
@@ -4256,6 +4261,7 @@ landscape:
               dev_stats_url: https://bfe.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#bfe-logos
               clomonitor_name: bfe
+              tag: network
           - item:
             name: Caddy
             description: Caddy is a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go
@@ -4286,6 +4292,7 @@ landscape:
               dev_stats_url: https://contour.devstats.cncf.io/
               slack_url: https://kubernetes.slack.com/messages/contour
               clomonitor_name: contour
+              tag: network
               audits:
                 - date: '2021-12-01'
                   type: security
@@ -4353,6 +4360,7 @@ landscape:
               chat_channel: '#metallb'
               dev_stats_url: https://metallb.devstats.cncf.io/
               clomonitor_name: metallb
+              tag: network
           - item:
             name: MOSN
             homepage_url: https://mosn.io
@@ -4532,6 +4540,7 @@ landscape:
               summary_integration: Telepresence, Linkerd, Istio, Argo Rollouts, Envoy, gRPC, OpenTelemetry, Curiefense
               summary_intro_url: ''
               clomonitor_name: emissary-ingress
+              tag: network
           - item:
             name: EnRoute OneStep Ingress
             homepage_url: https://www.getenroute.io
@@ -4807,6 +4816,7 @@ landscape:
                 Kuma is a service mesh that combines the extensibility and performance of Envoy proxy with great UX and a powerful, yet flexible set of
                 policies. It was built from the ground up to support Kubernetes, Docker, and VM environments seamlessly in a single deployment.
               clomonitor_name: kuma
+              tag: network
           - item:
             name: Linkerd
             description: Ultra light, ultra simple, ultra powerful. Linkerd adds security, observability, and reliability to Kubernetes, without the complexity.
@@ -5897,6 +5907,7 @@ landscape:
               summary_integrations: Docker, Kubernetes, K3S, WASMCloud, CloudEvents, Helm, Argo, DAPR, Prometheus, Benthos
               summary_intro_url: https://rethink.synadia.com/episodes/1/
               clomonitor_name: nats
+              tag: network
               audits:
                 - date: '2019-02-06'
                   type: security


### PR DESCRIPTION
Updating the projects identified in the [TAG Security README](https://github.com/cncf/tag-network?tab=readme-ov-file#current-cncf-network-centric-projects) as network centric projects.

It is in preperation for the replacement of the list of projects on the README with a filtered [TAG Network landscape link](https://landscape.cncf.io/?group=projects-and-products&view-mode=grid&tag=network&project=cncf).