### PR TITLE
Remove keywhiz

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2258,13 +2258,6 @@ landscape:
               summary_integration: SPIFFE, Kubernetes, Envoy, Istio, AWS, GCP, Azure, Vault, Cilium, CertManager
               summary_intro_url: https://www.youtube.com/watch?v=Q2SiGeebRKY
           - item:
-            name: Square Keywhiz
-            homepage_url: https://square.github.io/keywhiz/
-            repo_url: https://github.com/square/keywhiz
-            logo: square-keywhiz.svg
-            twitter: https://twitter.com/SquareEng
-            crunchbase: https://www.crunchbase.com/organization/square
-          - item:
             name: sso
             homepage_url: https://github.com/buzzfeed/sso
             repo_url: https://github.com/buzzfeed/sso


### PR DESCRIPTION
The keywhiz project is archived, deprecated and no longer maintained according to their github page, so propose it is removed from the CNCF landscape https://github.com/square/keywhiz

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

*[ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
