### PR TITLE
Add new sub-category: Runtime/Runtime Systems

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -177,35 +177,6 @@ landscape:
             twitter: https://twitter.com/ubuntu
             crunchbase: https://www.crunchbase.com/organization/canonical-ltd
           - item:
-            name: Kairos
-            homepage_url: https://kairos.io
-            project: sandbox
-            repo_url: https://github.com/kairos-io/kairos
-            logo: kairos.svg
-            twitter: https://twitter.com/Kairos_OSS
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            extra:
-              accepted: '2024-04-13'
-              summary_personas: >-
-                Cluster admins, SREs, Cloud Architects, Platform Engineers, DevOps Engineer, DevOps practitioners, DevSecOps practitioners
-              summary_tags: >-
-                security, Go, DevOps, DevSecOps, container, Cloud Native, Kubernetes, Runtime, Kubernetes, baremetal
-              summary_use_case: Transform any Linux system into a secure, customizable, and easily managed platform for edge computing with or without Kubernetes.
-              summary_business_use_case: >-
-                Kairos can be utilized by businesses to deploy secure, consistent, and easily managed edge computing platforms across multiple locations.
-                For instance, a retail chain can transform its in-store Linux systems into customized, secure, and uniform environments.
-                This setup ensures seamless deployment and management of applications, enhances data security through immutable images and encryption,
-                and reduces maintenance overhead. The system's compatibility with Kubernetes and ease of installation make it an optimal choice
-                for scalable and automated edge computing solutions.
-              summary_release_rate: At least one minor release per quarter
-              summary_integrations: >-
-                K3s, Kubeadm, rke2, microk8s, Calico, Cert-manager, Flux, Kyverno, Kubevirt, Longhorn, MetalLB, Multus, Nginx, System upgrade controller, EdgeVPN
-              summary_intro_url: https://www.youtube.com/watch?v=WzKf6WrL3nE
-              blog_url: https://kairos.io/blog/
-              slack_url: https://cloud-native.slack.com/archives/C0707M8UEU8
-              youtube_url: https://www.youtube.com/@Kairos-IO
-              clomonitor_name: kairos
-          - item:
             name: Kapitan
             description: A configuration management system for platform engineering and other things
             homepage_url: https://kapitan.dev/
@@ -2398,6 +2369,54 @@ landscape:
   - category:
     name: Runtime
     subcategories:
+      - subcategory:
+        name: Runtime Systems
+        items:
+          - item:
+            name: Kairos
+            homepage_url: https://kairos.io
+            project: sandbox
+            repo_url: https://github.com/kairos-io/kairos
+            logo: kairos.svg
+            twitter: https://twitter.com/Kairos_OSS
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              accepted: '2024-04-13'
+              summary_personas: >-
+                Cluster admins, SREs, Cloud Architects, Platform Engineers, DevOps Engineer, DevOps practitioners, DevSecOps practitioners
+              summary_tags: >-
+                security, Go, DevOps, DevSecOps, container, Cloud Native, Kubernetes, Runtime, Kubernetes, baremetal
+              summary_use_case: Transform any Linux system into a secure, customizable, and easily managed platform for edge computing with or without Kubernetes.
+              summary_business_use_case: >-
+                Kairos can be utilized by businesses to deploy secure, consistent, and easily managed edge computing platforms across multiple locations.
+                For instance, a retail chain can transform its in-store Linux systems into customized, secure, and uniform environments.
+                This setup ensures seamless deployment and management of applications, enhances data security through immutable images and encryption,
+                and reduces maintenance overhead. The system's compatibility with Kubernetes and ease of installation make it an optimal choice
+                for scalable and automated edge computing solutions.
+              summary_release_rate: At least one minor release per quarter
+              summary_integrations: >-
+                K3s, Kubeadm, rke2, microk8s, Calico, Cert-manager, Flux, Kyverno, Kubevirt, Longhorn, MetalLB, Multus, Nginx, System upgrade controller, EdgeVPN
+              summary_intro_url: https://www.youtube.com/watch?v=WzKf6WrL3nE
+              blog_url: https://kairos.io/blog/
+              slack_url: https://cloud-native.slack.com/archives/C0707M8UEU8
+              youtube_url: https://www.youtube.com/@Kairos-IO
+              clomonitor_name: kairos
+          - item:
+            name: Flatcar Container Linux
+            description: >-
+              A community Linux distribution designed for container workloads, with high security and low maintenance
+            homepage_url: https://www.flatcar.org/
+            repo_url: https://github.com/flatcar/Flatcar
+            logo: flatcar.svg
+            project: incubating
+            twitter: https://twitter.com/flatcar
+            second_path:
+              - "Wasm / Edge/Bare metal"
+            extra:
+              accepted: '2024-08-02'
+              incubating: '2024-08-02'
+              clomonitor_name: flatcar
+              dev_stats_url: https://flatcar.devstats.cncf.io/
       - subcategory:
         name: Cloud Native Storage
         items:
@@ -8069,22 +8088,6 @@ landscape:
             logo: flant-deckhouse.svg
             twitter: https://twitter.com/deckhouseio
             crunchbase: https://www.crunchbase.com/organization/flant
-          - item:
-            name: Flatcar Container Linux
-            description: >-
-              A community Linux distribution designed for container workloads, with high security and low maintenance
-            homepage_url: https://www.flatcar.org/
-            repo_url: https://github.com/flatcar/Flatcar
-            logo: flatcar.svg
-            project: incubating
-            twitter: https://twitter.com/flatcar
-            second_path:
-              - "Wasm / Edge/Bare metal"
-            extra:
-              accepted: '2024-08-02'
-              incubating: '2024-08-02'
-              clomonitor_name: flatcar
-              dev_stats_url: https://flatcar.devstats.cncf.io/
           - item:
             name: Fury Distribution
             description: >-


### PR DESCRIPTION
Following discussions in the Special Purpose Operating Systems (SPOS) work group within the Runtime TAG, we've introduced a new “Runtime/Operating Systems” sub-category. This replaces the previous classification, which didn't accurately represent the projects within the group.

The updated sub-category will better align with the SPOS WG projects and accommodate other projects that may join the foundation in the future.

This version is concise and directly conveys the motivation and future scope of the change. Let me know if you’d like to adjust any details!