### PR TITLE
Project Updates (second_path & relocate flatcar)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3933,6 +3933,9 @@ landscape:
             twitter: https://twitter.com/KnativeProject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Serverless / Installable Platform"
+              - "Wasm / Embedded Functions"
             extra:
               accepted: '2022-03-02'
               incubating: '2022-03-02'
@@ -9490,48 +9493,6 @@ landscape:
             logo: fission.svg
             twitter: https://twitter.com/fissionio
             crunchbase: https://www.crunchbase.com/organization/infracloud-technologies
-          - item:
-            name: Knative (Serverless)
-            description: >-
-              Knative is a developer-focused serverless application layer which is a great complement to the existing Kubernetes application constructs. Knative
-              consists of three components: an HTTP-triggered autoscaling container runtime called “Knative Serving”, a CloudEvents-over-HTTP asynchronous
-              routing layer called “Knative Eventing”, and a developer-focused function framework which leverages the Serving and Eventing components, called
-              "Knative Functions".
-            homepage_url: https://knative.dev
-            project: incubating
-            repo_url: https://github.com/knative/serving
-            logo: knative.svg
-            twitter: https://twitter.com/KnativeProject
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2022-03-02'
-              incubating: '2022-03-02'
-              dev_stats_url: https://knative.teststats.cncf.io/
-              artwork_url: https://github.com/knative/docs/tree/main/docs/images/logo
-              stack_overflow_url: https://stackoverflow.com/questions/tagged/knative
-              mailing_list_url: https://groups.google.com/d/forum/knative-users
-              slack_url: https://slack.cncf.io
-              youtube_url: https://www.youtube.com/c/KnativeProject
-              clomonitor_name: knative
-              audits:
-                - date: '2023-07-13'
-                  type: fuzzing
-                  url: https://github.com/knative/docs/tree/main/reports/ADA-knative-fuzzing-audit-22-23.pdf
-                  vendor: Ada Logics
-              summary_personas: Cloud Architects, Cloud Developers, Platform Engineers, DevOps Engineers, DevOps Practitioners
-              summary_tags: Serverless, CloudEvents, Functions, Scaling, Applications
-              summary_use_case: >-
-                Knative is system that helps teams develop, build, manage, and maintain processes in Kubernetes. Its purpose is to simplify, automate, and
-                monitor deployments of Kubernetes so teams spend less time on maintenance and more time on app development and projects. Knative takes over
-                repetitive and time-intensive tasks while removing obstacles and delays.
-              summary_business_use_case: >-
-                The power of Knative’s eventing and serverless features allows companies to bridge processes between external eventing systems with services and
-                functions in Kubernetes.
-              summary_release_rate: Quarterly major releases
-              summary_integrations: Apache Kafka, RabbitMQ, Redis, CNCF Buildpacks, Docker, Podman
-              summary_languages: Go, Java, Node.js, Python, Rust
-              summary_intro_url: https://knative.dev/docs/getting-started/
           - item:
             name: Knix
             homepage_url: https://github.com/knix-microfunctions/knix?tab=readme-ov-file
@@ -18335,13 +18296,6 @@ landscape:
             repo_url: https://github.com/istio/istio
             logo: istio.svg
             twitter: https://twitter.com/IstioMesh
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-          - item:
-            name: Knative (Wasm)
-            homepage_url: https://knative.dev
-            repo_url: https://github.com/knative/serving
-            logo: knative.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
           - item:

--- a/landscape.yml
+++ b/landscape.yml
@@ -1655,6 +1655,8 @@ landscape:
             twitter: https://twitter.com/openpolicyagent
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Serverless / Embedded Functions"
             extra:
               accepted: '2018-03-29'
               incubating: '2019-04-02'
@@ -18329,13 +18331,6 @@ landscape:
             repo_url: https://github.com/nginx/nginx
             logo: nginx.svg
             crunchbase: https://www.crunchbase.com/organization/nginx
-            allow_duplicate_repo: true
-          - item:
-            name: OPA
-            homepage_url: https://www.openpolicyagent.org/
-            repo_url: https://github.com/open-policy-agent/opa
-            logo: opa.svg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
           - item:
             name: OpenGauss

--- a/landscape.yml
+++ b/landscape.yml
@@ -3263,6 +3263,8 @@ landscape:
             logo: virtual-kubelet.svg
             twitter: https://twitter.com/virtualkubelet
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "Serverless / Installable Platform"
             extra:
               accepted: '2018-12-04'
               dev_stats_url: https://virtualkubelet.devstats.cncf.io/
@@ -9559,20 +9561,6 @@ landscape:
             repo_url: https://github.com/pipelineai/pipeline
             logo: pipeline-ai.svg
             crunchbase: https://www.crunchbase.com/organization/pipelineio
-          - item:
-            name: Virtual Kubelet (Serverless)
-            homepage_url: https://virtual-kubelet.io/
-            project: sandbox
-            logo: virtual-kubelet.svg
-            twitter: https://twitter.com/virtualkubelet
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            extra:
-              accepted: '2018-12-04'
-              dev_stats_url: https://virtualkubelet.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#virtual-kubelet-logos
-              clomonitor_name: virtual-kubelet
-              annual_review_url: https://github.com/cncf/toc/pull/1077
-              annual_review_date: '2023-06-08'
   - category:
     name: Observability and Analysis
     subcategories:

--- a/landscape.yml
+++ b/landscape.yml
@@ -4245,6 +4245,8 @@ landscape:
             logo: volcano.svg
             twitter: https://twitter.com/volcano_sh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "CNAI / General Orchestration"
             extra:
               accepted: '2020-04-09'
               dev_stats_url: https://volcano.devstats.cncf.io/
@@ -18743,14 +18745,6 @@ landscape:
     - subcategory:
       name: General Orchestration
       items:
-        - item:
-          name: Volcano
-          description: Cloud native batch scheduling system for compute-intensive workloads
-          homepage_url: https://volcano.sh/
-          repo_url: https://github.com/volcano-sh/volcano
-          logo: ./volcano_logo.svg
-          crunchbase:
-          unnamed_organization: true
         - item:
           name: Armada
           description: Armada is a multi-kubernetes-cluster batch job meta-scheduler.

--- a/landscape.yml
+++ b/landscape.yml
@@ -4049,6 +4049,9 @@ landscape:
             twitter: https://twitter.com/kubernetesio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Wasm / Orchestration & Management"
+              - "CNAI / General Orchestration"
             extra:
               accepted: '2016-03-10'
               incubating: '2016-03-10'
@@ -18503,13 +18506,6 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
           - item:
-            name: Kubernetes (Wasm)
-            homepage_url: https://kubernetes.io/
-            repo_url: https://github.com/kubernetes/kubernetes
-            logo: kubernetes.svg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-          - item:
             name: Kwasm
             homepage_url: https://kwasm.sh/
             repo_url: https://github.com/KWasm/kwasm-operator
@@ -18745,38 +18741,6 @@ landscape:
     - subcategory:
       name: General Orchestration
       items:
-        - item:
-          name: Kubernetes
-          description: Kubernetes is an open-source system for automating deployment, scaling, and management of containerized applications
-          homepage_url: https://kubernetes.io/
-          project: graduated
-          repo_url: https://github.com/kubernetes/kubernetes
-          logo: kubernetes.svg
-          twitter: https://twitter.com/kubernetesio
-          crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-          allow_duplicate_repo: true
-          extra:
-            accepted: '2016-03-10'
-            incubating: '2016-03-10'
-            graduated: '2018-03-06'
-            tag: runtime
-            dev_stats_url: https://k8s.devstats.cncf.io/
-            artwork_url: https://github.com/cncf/artwork/blob/master/examples/graduated.md#kubernetes-logos
-            stack_overflow_url: https://stackoverflow.com/questions/tagged/kubernetes
-            blog_url: http://blog.kubernetes.io/
-            mailing_list_url: https://groups.google.com/forum/#!forum/kubernetes-dev
-            slack_url: http://slack.k8s.io/
-            youtube_url: https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg
-            clomonitor_name: kubernetes
-            audits:
-              - date: '2019-08-06'
-                type: security
-                url: https://github.com/kubernetes/sig-security/tree/main/sig-security-external-audit/security-audit-2019/findings
-                vendor: Trail of Bits and Atredis Partners
-              - date: '2023-04-19'
-                type: security
-                url: https://github.com/kubernetes/sig-security/tree/main/sig-security-external-audit/security-audit-2021-2022/findings
-                vendor: NCC Group
         - item:
           name: Volcano
           description: Cloud native batch scheduling system for compute-intensive workloads

--- a/landscape.yml
+++ b/landscape.yml
@@ -1535,6 +1535,8 @@ landscape:
             logo: kyverno.svg
             twitter: https://twitter.com/kyverno
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "CNAI / Governance, Policy & Security"
             extra:
               accepted: '2020-11-10'
               incubating: '2022-07-13'
@@ -19308,14 +19310,6 @@ landscape:
             blog_url: https://authzed.com/blog
             youtube_url: https://youtube.com/@authzed
             slack_url: https://discord.gg/spicedb
-        - item:
-          name: Kyverno
-          description: A policy engine designed for Kubernetes platform engineering teams.
-          repo_url: https://github.com/kyverno/kyverno
-          logo: ./kyverno-icon-color.svg
-          crunchbase:
-          unnamed_organization: true
-          homepage_url: https://kyverno.io
         - item:
           name: OPA/Gatekeeper
           description: An admission controller that validates requests to create and update Pods on Kubernetes clusters, using the Open Policy Agent (OPA).

--- a/landscape.yml
+++ b/landscape.yml
@@ -3813,6 +3813,8 @@ landscape:
             open_source: true
             twitter: null
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "CNAI / General Orchestration"
             extra:
               accepted: '2024-08-21'
               clomonitor_name: hami
@@ -18789,20 +18791,6 @@ landscape:
           crunchbase:
           unnamed_organization: true
           homepage_url: https://kueue.sigs.k8s.io/
-        - item:
-          name: HAMi
-          description: Heterogeneous AI Computing Virtualization (vGPU)
-          homepage_url: https://github.com/Project-HAMi/HAMi
-          repo_url: https://github.com/Project-HAMi/HAMi
-          logo: ./hami.svg
-          unnamed_organization: true
-          project: sandbox
-          open_source: true
-          twitter: null
-          crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-          extra:
-            accepted: '2024-08-21'
-            clomonitor_name: hami
     - subcategory:
       name: ML Serving
       items:

--- a/landscape.yml
+++ b/landscape.yml
@@ -6549,6 +6549,9 @@ landscape:
             twitter: https://twitter.com/DaprDev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Wasm / Embedded Functions"
+              - "Serverless / Framework"
             extra:
               accepted: '2021-11-09'
               incubating: '2021-11-09'
@@ -9177,48 +9180,6 @@ landscape:
             repo_url: https://github.com/aws/chalice
             logo: chalice.svg
             crunchbase: https://www.crunchbase.com/organization/amazon-web-services
-          - item:
-            name: Dapr (Serverless)
-            homepage_url: https://dapr.io
-            project: incubating
-            repo_url: https://github.com/dapr/dapr
-            logo: dapr.svg
-            twitter: https://twitter.com/DaprDev
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2021-11-09'
-              incubating: '2021-11-09'
-              dev_stats_url: https://dapr.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#dapr-logos
-              blog_url: https://blog.dapr.io/posts
-              slack_url: https://discord.com/invite/ptHhX6jc34
-              summary_personas: Developers, Platform engineers
-              summary_tags: Developer APIs, Distributed Systems, Microservices, HTTP, gRPC, Go, Java, Python, .NET, Javascript, C++, Rust, CLI
-              summary_use_case: >-
-                The Distributed Application Runtime (Dapr) provides APIs that simplify microservice architecture development and increases developer
-                productivity. Whether your communication pattern is service-to-service invocation or pub/sub messaging, Dapr helps you write resilient and
-                secured microservices. By letting Dapr’s sidecar take care of the complex challenges such as service discovery, message broker integration,
-                encryption, observability, and secret management, developers can focus on business logic and keep their code simple.
-              summary_business_use_case: >-
-                Deliver distributed system applications in half the time. Dapr provides APIs that abstract away the complexity of common challenges developers
-                encounter regularly when building distributed applications. These API building blocks can be leveraged as the need arises - use one, several, or
-                all to develop applications faster and deliver solutions on time. Dapr leverages proven practices for distributed application development that
-                enable developers to build resilient, secured systems. By using Dapr in your application, you adopt these best practices without having to spend
-                time solving common challenges.
-              summary_release_rate: 4 times per year (each quarter)
-              summary_integration: Kubernetes, Docker, Open Telemetry, gRPC, CloudEvents, spiffe, Knative, Helm, Prometheus, Cert Manager
-              summary_intro_url: https://youtu.be/9o9iDAgYBA8
-              clomonitor_name: dapr
-              audits:
-                - date: '2023-06-30'
-                  type: fuzzing
-                  url: https://docs.dapr.io/docs/Dapr-june-2023-fuzzing-audit-report.pdf
-                  vendor: Ada Logics
-                - date: '2023-09-05'
-                  type: security
-                  url: https://docs.dapr.io/docs/Dapr-september-2023-security-audit-report.pdf
-                  vendor: Ada Logics
           - item:
             name: Encore
             homepage_url: https://encore.dev
@@ -18438,13 +18399,6 @@ landscape:
       - subcategory:
         name: Embedded Functions
         items:
-          - item:
-            name: Dapr (Wasm)
-            homepage_url: https://dapr.io
-            repo_url: https://github.com/dapr/dapr
-            logo: dapr.svg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
           - item:
             name: eKuiper
             homepage_url: https://ekuiper.org

--- a/landscape.yml
+++ b/landscape.yml
@@ -4162,6 +4162,9 @@ landscape:
             twitter: https://twitter.com/openfunctiondev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Serverless / Installable Platforms"
+              - "Wasm / Embedded Functions"
             extra:
               accepted: '2022-04-26'
               dev_stats_url: https://openfunction.devstats.cncf.io/
@@ -9550,38 +9553,6 @@ landscape:
             repo_url: https://github.com/openfaas/faas
             logo: openfaas.svg
             crunchbase: https://www.crunchbase.com/organization/openfaas
-          - item:
-            name: OpenFunction (Serverless)
-            homepage_url: https://openfunction.dev
-            project: sandbox
-            repo_url: https://github.com/OpenFunction/OpenFunction
-            logo: openfunction.svg
-            twitter: https://twitter.com/openfunctiondev
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2022-04-26'
-              dev_stats_url: https://openfunction.devstats.cncf.io/
-              blog_url: https://openfunction.dev/blog/
-              slack_url: https://slack.cncf.io/
-              chat_channel: '#openfunction'
-              summary_personas: Developers, Platform engineers
-              summary_tags: FaaS, Serverless, KEDA, Knative, Shipwright, Buildpacks, Distributed Systems
-              summary_use_case: >-
-                Users can use OpenFunction in several different ways including building functions or applications only, running sync or async serverless
-                functions or applications, building and then running serverless functions or applications, building and then running serverless wasm
-                applications(In progress).  In all use cases, users can utilize Dapr to communicate with various backend services (BaaS).
-              summary_business_use_case: >-
-                OpenFunction is a cloud-native open source FaaS (Function as a Service) platform aiming to let users focus on their business logic without
-                having to  maintain the underlying runtime environment and infrastructure. Users can generate event-driven and dynamically scaling Serverless
-                workloads by simply  submitting business-related source code in the form of functions. Users can also build and run serverless applications as
-                well.
-              summary_release_rate: 3 ~ 4 major releases per year
-              summary_integration: Knative, Dapr, KEDA, Shipwright, Kubernetes Gateway API, Contour
-              summary_intro_url: https://openfunction.dev/docs/
-              clomonitor_name: openfunction
-              annual_review_url: https://github.com/cncf/toc/pull/1097
-              annual_review_date: '2023-06-23'
           - item:
             name: PipelineAI
             homepage_url: https://www.datascienceonaws.com
@@ -18440,17 +18411,6 @@ landscape:
             logo: opa.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
-          - item:
-            name: OpenFunction (Wasm)
-            homepage_url: https://openfunction.dev
-            project: sandbox
-            repo_url: https://github.com/OpenFunction/OpenFunction
-            logo: openfunction.svg
-            twitter: https://twitter.com/openfunctiondev
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              clomonitor_name: openfunction
           - item:
             name: OpenGauss
             homepage_url: https://opengauss.org/en/

--- a/landscape.yml
+++ b/landscape.yml
@@ -3166,6 +3166,8 @@ landscape:
             twitter: https://twitter.com/krustlet
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Wasm / Runtimes"
             extra:
               accepted: '2021-07-13'
               archived: '2024-09-30'
@@ -18101,18 +18103,6 @@ landscape:
       - subcategory:
         name: Runtimes
         items:
-          - item:
-            name: Krustlet (Wasm)
-            homepage_url: https://krustlet.dev
-            project: sandbox
-            repo_url: https://github.com/krustlet/krustlet
-            logo: krustlet.svg
-            twitter: https://twitter.com/krustlet
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2021-07-13'
-              clomonitor_name: krustlet
           - item:
             name: Lunatic
             homepage_url: https://lunatic.solutions/

--- a/landscape.yml
+++ b/landscape.yml
@@ -4225,6 +4225,8 @@ landscape:
             repo_url: https://github.com/serverless-devs/serverless-devs
             logo: serverless-devs.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "Serverless / Tools"
             extra:
               accepted: '2022-09-14'
               clomonitor_name: serverless-devs
@@ -9172,15 +9174,6 @@ landscape:
             repo_url: https://github.com/grycap/scar
             logo: scar.svg
             crunchbase: https://www.crunchbase.com/organization/polytechnic-university-of-valencia
-          - item:
-            name: Serverless Devs (Serverless)
-            homepage_url: https://www.serverless-devs.com/
-            project: sandbox
-            logo: serverless-devs.svg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            extra:
-              accepted: '2022-09-14'
-              clomonitor_name: serverless-devs
           - item:
             name: Sigma
             description: Sigma is a serverless application developer tool; a cloud IDE, which helps you rapidly build, test and deploy serverless applications.

--- a/landscape.yml
+++ b/landscape.yml
@@ -3807,6 +3807,8 @@ landscape:
               annual_review_url: https://github.com/cncf/toc/pull/870
               annual_review_date: '2022-07-06'
               clomonitor_name: fluid
+            second_path:
+              - "CNAI / Data Architecture"
           - item:
             name: hami
             description: Heterogeneous AI Computing Virtualization Middleware
@@ -19245,14 +19247,6 @@ landscape:
           crunchbase:
           unnamed_organization: true
           homepage_url: https://pulsar.apache.org/
-        - item:
-          name: Fluid
-          description: elastic data abstraction and acceleration for BigData/AI applications in the cloud.
-          repo_url: https://github.com/fluid-cloudnative/fluid
-          logo: ./fluid-icon-color.svg
-          crunchbase:
-          unnamed_organization: true
-          homepage_url: https://fluid-cloudnative.github.io/
         - item:
           name: Memcached
           description: A high performance multithreaded event-based key/value cache store intended to be used in a distributed system.

--- a/landscape.yml
+++ b/landscape.yml
@@ -8054,6 +8054,22 @@ landscape:
             twitter: https://twitter.com/deckhouseio
             crunchbase: https://www.crunchbase.com/organization/flant
           - item:
+            name: Flatcar Container Linux
+            description: >-
+              A community Linux distribution designed for container workloads, with high security and low maintenance
+            homepage_url: https://www.flatcar.org/
+            repo_url: https://github.com/flatcar/Flatcar
+            logo: flatcar.svg
+            project: incubating
+            twitter: https://twitter.com/flatcar
+            second_path:
+              - "Wasm / Edge/Bare metal"
+            extra:
+              accepted: '2024-08-02'
+              incubating: '2024-08-02'
+              clomonitor_name: flatcar
+              dev_stats_url: https://flatcar.devstats.cncf.io/
+          - item:
             name: Fury Distribution
             description: >-
               Kubernetes Fury is a battle-tested distribution purely based on upstream Kubernetes. Deploy and manage a stable and production grade Kubernetes
@@ -18190,17 +18206,6 @@ landscape:
       - subcategory:
         name: Edge/Bare metal
         items:
-          - item:
-            name: Flatcar Container Linux
-            homepage_url: https://www.flatcar.org/
-            repo_url: https://github.com/flatcar/Flatcar
-            logo: flatcar.svg
-            project: incubating
-            extra:
-              accepted: '2024-08-02'
-              clomonitor_name: flatcar
-              incubating: '2024-08-02'
-            unnamed_organization: true
           - item:
             name: Genode
             homepage_url: https://genode.org/

--- a/landscape.yml
+++ b/landscape.yml
@@ -3637,6 +3637,8 @@ landscape:
             logo: armada.svg
             twitter: https://twitter.com/oss_gr
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "CNAI / General Orchestration"
             extra:
               accepted: '2022-07-25'
               dev_stats_url: https://armada.devstats.cncf.io/
@@ -18745,14 +18747,6 @@ landscape:
     - subcategory:
       name: General Orchestration
       items:
-        - item:
-          name: Armada
-          description: Armada is a multi-kubernetes-cluster batch job meta-scheduler.
-          homepage_url: https://armadaproject.io/
-          repo_url: https://github.com/armadaproject/armada
-          logo: ./armada.svg
-          crunchbase:
-          unnamed_organization: true
         - item:
           name: Kuberay
           description: A toolkit to run Ray applications on Kubernetes

--- a/landscape.yml
+++ b/landscape.yml
@@ -3281,6 +3281,10 @@ landscape:
             twitter: https://twitter.com/realwasmedge
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Wasm / Runtimes"
+              - "Wasm / Application Frameworks"
+              - "CNAI / ML Serving"
             extra:
               accepted: '2021-04-28'
               annual_review_url: https://github.com/cncf/toc/pull/1109
@@ -18102,21 +18106,6 @@ landscape:
             logo: wasm3.svg
             unnamed_organization: true
           - item:
-            name: WasmEdge (Wasm)
-            homepage_url: https://wasmedge.org/
-            project: sandbox
-            repo_url: https://github.com/WasmEdge/WasmEdge
-            logo: wasm-edge.svg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2021-04-28'
-              annual_review_url: https://github.com/cncf/toc/pull/873
-              annual_review_date: '2022-07-09'
-              slack_url: https://cloud-native.slack.com/
-              chat_channel: '#WasmEdge'
-              clomonitor_name: wasm-edge
-          - item:
             name: Wasmer
             homepage_url: https://wasmer.io
             repo_url: https://github.com/wasmerio/wasmer
@@ -18224,13 +18213,6 @@ landscape:
             repo_url: https://github.com/wasmCloud/wasmCloud
             logo: wasmcloud.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-          - item:
-            name: WasmEdge Plugin System
-            homepage_url: https://wasmedge.org/docs/start/wasmedge/extensions/plugins
-            repo_url: https://github.com/WasmEdge/WasmEdge
-            logo: wasmedge-plugin.svg
-            crunchbase: https://www.crunchbase.com/organization/second-state
             allow_duplicate_repo: true
           - item:
             name: Wasmex
@@ -18933,38 +18915,6 @@ landscape:
           crunchbase:
           unnamed_organization: true
           homepage_url: https://huggingface.co/docs/text-generation-inference/index
-        - item:
-          name: WasmEdge Runtime
-          homepage_url: https://llamaedge.com/docs/intro/
-          project: sandbox
-          repo_url: https://github.com/WasmEdge/WasmEdge
-          logo: wasmedge.svg
-          twitter: https://twitter.com/realwasmedge
-          crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-          allow_duplicate_repo: true
-          extra:
-            accepted: '2021-04-28'
-            annual_review_url: https://github.com/cncf/toc/pull/1109
-            annual_review_date: '2023-07-04'
-            dev_stats_url: https://wasmedge.devstats.cncf.io/
-            artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#wasmedgeruntime-logos
-            summary_personas: Developers, DevOps Engineers
-            summary_tags: Edge Cloud, Edge Devices, Container, Embedded runtime, Serverless, UDF, Microservices, Streaming data, OCI Runtime,SaaS
-            summary_use_case: >
-              WasmEdge provides a high-performance, lightweight, secure, and extensible WebAssembly runtime for cloud-native applications. It is an OCI
-              compliant container that is integrated into Docker, containerd, crun and many Kubernetes projects.  Compared with traditional Linux container
-              apps, WasmEdge apps are more secure, more portable, cold-start 100x faster and only take 1/10 of the space.
-            summary_business_use_case: >-
-              WasmEdge improves cloud app’s operational efficiency by providing a secure, portable, fast, and lightweight alternative to traditional Linux
-              containers. It allows microservice or servelsss applications to “scale to zero” — all computing resources can be made available on-demand, and
-              “write once run anywhere”. It also works with existing container management infra and programming languages, and hence minimizing the cost of
-              adoption and migration. It is great for running microservices and serverless functions embedded in data pipelines or SaaS platforms.
-            summary_release_rate: Every 3 months
-            summary_integrations: >-
-                Crun, Runwasi, Youki, Docker Desktop, Kubernetes, WebAssembly Languages Runtime maintained by VMWare, Proxy-wasm, Knative, SuperEdge, OpenYurt,
-                KubeEdge, Fedora Linux
-            summary_intro_url: https://youtu.be/Kg5z5A5wH0A
-            clomonitor_name: wasm-edge
     - subcategory:
       name: CI/CD - Delivery
       items:

--- a/landscape.yml
+++ b/landscape.yml
@@ -1498,6 +1498,8 @@ landscape:
             twitter: https://twitter.com/kubewarden
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Wasm / Embedded Functions"
             extra:
               accepted: '2022-06-17'
               blog_url: https://kubewarden.io/blog
@@ -18318,17 +18320,6 @@ landscape:
             repo_url: https://github.com/kubernetes-sigs/scheduler-plugins
             logo: kubernetes.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-          - item:
-            name: Kubewarden (Wasm)
-            homepage_url: https://www.kubewarden.io
-            project: sandbox
-            repo_url: https://github.com/kubewarden/kubewarden-controller
-            logo: kubewarden.svg
-            twitter: https://twitter.com/kubewarden
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              clomonitor_name: kubewarden
           - item:
             name: libSQL
             homepage_url: https://libsql.org/

--- a/landscape.yml
+++ b/landscape.yml
@@ -3881,6 +3881,8 @@ landscape:
             twitter: https://twitter.com/kedaorg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
+            second_path:
+              - "Serverless / Installable Platform"
             extra:
               accepted: '2020-03-12'
               incubating: '2021-08-18'
@@ -9477,30 +9479,6 @@ landscape:
             logo: fission.svg
             twitter: https://twitter.com/fissionio
             crunchbase: https://www.crunchbase.com/organization/infracloud-technologies
-          - item:
-            name: KEDA (Serverless)
-            homepage_url: https://keda.sh/
-            project: graduated
-            repo_url: https://github.com/kedacore/keda
-            logo: keda.svg
-            twitter: https://twitter.com/kedaorg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            allow_duplicate_repo: true
-            extra:
-              accepted: '2020-03-12'
-              incubating: '2021-08-18'
-              graduated: '2023-08-22'
-              dev_stats_url: https://keda.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#keda-logos
-              blog_url: https://keda.sh/blog
-              slack_url: https://kubernetes.slack.com/archives/CKZJ36A5D
-              youtube_url: https://www.youtube.com/playlist?list=PLvjRi5R9GQfASIcL4MLTfg2ZOoBdIi5Kq
-              clomonitor_name: keda
-              audits:
-                - date: '2023-02-02'
-                  type: security
-                  url: https://github.com/trailofbits/publications/blob/master/reviews/2023-01-keda-securityreview.pdf
-                  vendor: Trail of Bits
           - item:
             name: Knative (Serverless)
             description: >-


### PR DESCRIPTION
Dedupes projects that are located in multiple categories and switches them to using `second_path`.

Moves flatcar to Platform category so that  it is accounted for on the website correctly.