### PR TITLE
fix(kairos): point to correct youtube page

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -203,7 +203,7 @@ landscape:
               summary_intro_url: https://www.youtube.com/watch?v=WzKf6WrL3nE
               blog_url: https://kairos.io/blog/
               slack_url: https://cloud-native.slack.com/archives/C0707M8UEU8
-              youtube_url: https://www.youtube.com/@kairos_oss
+              youtube_url: https://www.youtube.com/@Kairos-IO
               clomonitor_name: kairos
           - item:
             name: Kapitan


### PR DESCRIPTION
The page that is linked doesn't exist anymore and yields to a 404. Replacing with the new Kairos youtube channel

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
