### PR TITLE
feat: add github url to metatype

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -18226,6 +18226,7 @@ landscape:
           - item:
             name: Metatype
             homepage_url: https://metatype.dev
+            repo_url: https://github.com/metatypedev/metatype
             logo: metatype.svg
             crunchbase: https://www.crunchbase.com/organization/metatype
           - item:


### PR DESCRIPTION
Metatype is now 100% open source ([ref](https://github.com/metatypedev/metatype/pull/899)).

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
