### PR TITLE
fix: project jupyter repo_url hyperlink

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -18937,7 +18937,7 @@ landscape:
         - item:
           name: Project Jupyter
           description: Interactive Computing
-          repo_url: https://github.com/jupyter
+          repo_url: https://github.com/jupyter/jupyter
           logo: ./jupyter_logo.svg
           crunchbase:
           unnamed_organization: true


### PR DESCRIPTION
### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?


This solves #4137 