### PR TITLE
Update landscape.yml - OpenSearch project now under The Linux Foundation

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -10739,7 +10739,7 @@ landscape:
             logo: opensearch.svg
             open_source: true
             twitter: https://twitter.com/opensearchproj
-            crunchbase: https://www.crunchbase.com/organization/amazon-web-services
+            crunchbase: https://www.crunchbase.com/organization/linux-foundation
             extra:
               blog_url: https://opensearch.org/blog/
               youtube_url: https://www.youtube.com/c/OpenSearchProject


### PR DESCRIPTION
Per the announcement at Open Source Summit Europe 2024, OpenSearch is now part of The Linux Foundation: https://www.linuxfoundation.org/press/linux-foundation-announces-opensearch-software-foundation-to-foster-open-collaboration-in-search-and-analytics

updated cunchbase URL accordingly.

Other metadata that indicates the owning organization in the landscape should also be updated accordingly (currently still indicating "Amazon Web Services")

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ x] Have you picked the single best (existing) category for your project?
* [x ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ x] Have you added your SVG to `hosted_logos` and referenced it there?
* [ x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x ] Does your project/product name match the text on the logo?
* [x ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
