### PR TITLE
chore: rename repo dragonflyoss/Dragonfly2 to dragonflyoss/dragonfly

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -659,7 +659,7 @@ landscape:
             name: Dragonfly
             homepage_url: https://d7y.io/
             project: incubating
-            repo_url: https://github.com/dragonflyoss/Dragonfly2
+            repo_url: https://github.com/dragonflyoss/dragonfly
             logo: dragonfly.svg
             twitter: https://twitter.com/dragonfly_oss
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation


### PR DESCRIPTION
Rename our repository from `Dragonfly2` to `dragonfly` to better align with our project naming conventions and to avoid any potential confusion. This change will help us maintain consistency across our project repositories and improve the overall clarity of our project structure.

Refer to https://github.com/dragonflyoss/dragonfly/issues/3714.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
