### PR TITLE
OVN-Kubernetes: Fix Slack URL

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3612,7 +3612,7 @@ landscape:
               accepted: '2024-10-17'
               dev_stats_url: https://ovn-kubernetes.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#ovn-kubernetes-logos
-              slack_url: https://cloud-native.slack.com/messages/ovn-kubernetes
+              slack_url: https://cloud-native.slack.com/messages/C08452HR8V6/details/
               mailing_list_url: https://groups.google.com/g/ovn-kubernetes
               summary_personas: Platform engineers, Network teams, SRE, DevOps Engineers
               summary_tags: CNI, Networking, Load Balancing, Network Security, Observability, Multicloud


### PR DESCRIPTION
Fix Slack URL so that https://github.com/cncf/landscape/actions/runs/11847006846/job/33015829564?pr=4111 is happy