### PR TITLE
Update Operator Framework Website

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7170,7 +7170,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/the-open-api-initiative
           - item:
             name: Operator Framework
-            homepage_url: https://www.redhat.com/en/technologies/cloud-computing/openshift/what-are-openshift-operators
+            homepage_url: https://operatorframework.io/
             project: incubating
             repo_url: https://github.com/operator-framework/operator-sdk
             logo: operator-framework.svg


### PR DESCRIPTION
As discussed with @angellk & @mrbobbytables the website is incorrect and pointing towards a Red Hat Website insteat of the official website

