### PR TITLE
CNCFSD-2642: Add website for Cartography

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1026,7 +1026,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/capsule8
           - item:
             name: Cartography
-            homepage_url: https://cartography-cncf.github.io/cartography/
+            homepage_url: https://cartography.dev
             logo: cartography.svg
             description: Cartography is a Python tool that consolidates infrastructure assets and the relationships between them in an intuitive graph view.
             project: sandbox


### PR DESCRIPTION
The Cartography project has a website now! https://cartography.dev.

Updates the link in landscape.yml.

See https://cncfservicedesk.atlassian.net/servicedesk/customer/portal/1/CNCFSD-2642.