### PR TITLE
Add Cloudsmith to the Container Registry Landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -814,13 +814,20 @@ landscape:
             twitter: https://twitter.com/IBMCloud
             crunchbase: https://www.crunchbase.com/organization/ibm
           - item:
+            name: Cloudsmith
+            description: >-
+              A single source of truth for every artifact and container. Cloudsmith is a powerful, cloud native, enterprise-grade artifact management solution.
+            homepage_url: https://cloudsmith.com/
+            logo: cloudsmith.svg
+            crunchbase: https://www.crunchbase.com/organization/cloudsmith-io              
+          - item:
             name: JFrog Artifactory
             description: >-
               Shipping updates continuously and automatically has become a critical element of any successful operation. JFrog is revolutionizing the software
               world with the practice of Continuous Update, with a speed and continuity that forever changes the way organizations manage and release software.
             homepage_url: https://jfrog.com/artifactory/
             logo: j-frog-artifactory.svg
-            crunchbase: https://www.crunchbase.com/organization/jfrog-ltd
+            crunchbase: https://www.crunchbase.com/organization/jfrog-ltd        
           - item:
             name: Kraken
             homepage_url: https://eng.uber.com/introducing-kraken/


### PR DESCRIPTION
Cloudsmith is already a CNCF member account and should be added to the container registry view: https://landscape.cncf.io/?group=members&item=cncf-members--silver--cloudsmith-member

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
