### PR TITLE
Fix Tinkerbell GitHub repository link

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -678,7 +678,7 @@ landscape:
             name: Tinkerbell
             homepage_url: https://tinkerbell.org/
             project: sandbox
-            repo_url: https://github.com/tinkerbell/tink
+            repo_url: https://github.com/tinkerbell/tinkerbell
             logo: tinkerbell.svg
             twitter: https://twitter.com/tinkerbell_oss
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation


### PR DESCRIPTION
Updated the Tinkerbell GitHub repository link to the correct URL.