### PR TITLE
Add ModelPack to Application Definition & Image Build (Sandbox)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6713,6 +6713,16 @@ landscape:
             logo: alibaba_fnf.svg
             crunchbase: https://www.crunchbase.com/organization/alibaba-cloud
           - item:
+            name: ModelPack
+            description: >-
+              The project establishes open standards for packaging, distributing and running AI artifacts in the cloud-native environment.
+            homepage_url: https://github.com/CloudNativeAI/model-spec
+            project: sandbox
+            repo_url: https://github.com/CloudNativeAI/model-spec
+            logo: cncf.svg
+            extra:
+              accepted: '2025-05-13'
+          - item:
             name: Artifact Hub
             homepage_url: https://artifacthub.io
             project: incubating

--- a/landscape.yml
+++ b/landscape.yml
@@ -6716,9 +6716,9 @@ landscape:
             name: ModelPack
             description: >-
               The project establishes open standards for packaging, distributing and running AI artifacts in the cloud-native environment.
-            homepage_url: https://github.com/CloudNativeAI/model-spec
+            homepage_url: https://github.com/modelpack/model-spec
             project: sandbox
-            repo_url: https://github.com/CloudNativeAI/model-spec
+            repo_url: https://github.com/modelpack/model-spec
             logo: cncf.svg
             extra:
               accepted: '2025-05-13'


### PR DESCRIPTION
This PR adds ModelPack under App Definition and Development → Application Definition & Image Build.

Fixes https://github.com/cncf/landscape/issues/4477