### PR TITLE
Update link and description for KServe page

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -19420,11 +19420,11 @@ landscape:
             dev_stats_url: https://kaito.devstats.cncf.io/
         - item:
           name: Kserve
-          description: Highly scalable and standards based Model Inference Platform on Kubernetes for Trusted AI
+          description: Standardized Distributed Generative and Predictive AI Inference Platform for Scalable, Multi-Framework Deployment on Kubernetes
           repo_url: https://github.com/kserve/kserve
           logo: ./k-serve-color.svg
           unnamed_organization: true
-          homepage_url: https://kserve.github.io/website/0.11/
+          homepage_url: https://kserve.github.io/website/
           project: incubating
           extra:
             accepted: '2025-09-29'


### PR DESCRIPTION
"Visit project website" leads to 404 page. This PR fixes it and updates the project description.





