### PR TITLE
fix: OAuth2 Proxy & SSO categorization

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1780,6 +1780,23 @@ landscape:
             extra:
               slack_url: https://io.permit.io/opal-slack
           - item:
+            name: OAuth2 Proxy
+            description: >-
+              A generic reverse proxy that provides authentication with Google, Azure, OpenID Connect and many more identity providers.
+            homepage_url: https://oauth2-proxy.github.io/oauth2-proxy/
+            project: sandbox
+            repo_url: https://github.com/oauth2-proxy/oauth2-proxy
+            project_org: https://github.com/oauth2-proxy
+            logo: oauth2-proxy.svg
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            additional_repos:
+              - repo_url: https://github.com/oauth2-proxy/manifests
+                repo_name: manifests
+            extra:
+              accepted: '2025-10-02'
+              dev_stats_url: https://oauth2-proxy.devstats.cncf.io/
+              clomonitor_name: oauth2-proxy
+          - item:
             name: Open Policy Agent (OPA)
             homepage_url: https://www.openpolicyagent.org/
             project: graduated
@@ -2163,6 +2180,13 @@ landscape:
             extra:
               slack_url: https://spyderbatcommunity.slack.com/
           - item:
+            name: sso
+            homepage_url: https://github.com/buzzfeed/sso
+            repo_url: https://github.com/buzzfeed/sso
+            logo: sso.svg
+            twitter: https://twitter.com/buzzfeedexp
+            crunchbase: https://www.crunchbase.com/organization/buzzfeed
+          - item:
             name: StackHawk
             description: StackHawk helps developers find and fix application security vulnerabilities before they hit production with CI/CD automation.
             homepage_url: https://www.stackhawk.com/index.html
@@ -2415,23 +2439,6 @@ landscape:
             twitter: https://twitter.com/ConjurInc
             crunchbase: https://www.crunchbase.com/organization/cyber-ark-software
           - item:
-            name: OAuth2 Proxy
-            description: >-
-              A generic reverse proxy that provides authentication with Google, Azure, OpenID Connect and many more identity providers.
-            homepage_url: https://oauth2-proxy.github.io/oauth2-proxy/
-            project: sandbox
-            repo_url: https://github.com/oauth2-proxy/oauth2-proxy
-            project_org: https://github.com/oauth2-proxy
-            logo: oauth2-proxy.svg
-            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-            additional_repos:
-              - repo_url: https://github.com/oauth2-proxy/manifests
-                repo_name: manifests
-            extra:
-              accepted: '2025-10-02'
-              dev_stats_url: https://oauth2-proxy.devstats.cncf.io/
-              clomonitor_name: oauth2-proxy
-          - item:
             name: ORY Hydra
             homepage_url: https://www.ory.sh/
             repo_url: https://github.com/ory/hydra
@@ -2558,13 +2565,6 @@ landscape:
               summary_release_rate: Monthly
               summary_integration: SPIFFE, Kubernetes, Envoy, Istio, AWS, GCP, Azure, Vault, Cilium, CertManager
               summary_intro_url: https://www.youtube.com/watch?v=Q2SiGeebRKY
-          - item:
-            name: sso
-            homepage_url: https://github.com/buzzfeed/sso
-            repo_url: https://github.com/buzzfeed/sso
-            logo: sso.svg
-            twitter: https://twitter.com/buzzfeedexp
-            crunchbase: https://www.crunchbase.com/organization/buzzfeed
           - item:
             name: Teller
             homepage_url: https://tlr.dev


### PR DESCRIPTION
Categorization of OAuth2 Proxy and SSO should be `Security & Compliance` and not `Key Management` both serve the same purpose as tools like Pomerium and Dex Idp. Best would be another section for `Identity & Access Management` but introducing a new section is out of the scope for this PR.
