### PR TITLE
chore: Remove Terraform and Vault entries as they were changed to BSL and are not considered Opensource as commonly defined today

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -668,12 +668,6 @@ landscape:
               chat_channel: '#superedge-community'
               clomonitor_name: superedge
           - item:
-            name: Terraform
-            homepage_url: https://www.terraform.io/
-            repo_url: https://github.com/hashicorp/terraform
-            logo: terraform.svg
-            crunchbase: https://www.crunchbase.com/organization/hashicorp
-          - item:
             name: Terranetes
             additional_repos:
               - repo_url: https://github.com/appvia/terranetes
@@ -2578,12 +2572,6 @@ landscape:
               accepted: '2022-04-26'
               mailing_list_url: https://github.com/tellerops/teller/discussions
               clomonitor_name: teller
-          - item:
-            name: Vault
-            homepage_url: https://www.vaultproject.io/
-            repo_url: https://github.com/hashicorp/vault
-            logo: vault.svg
-            crunchbase: https://www.crunchbase.com/organization/hashicorp
   - category:
     name: Runtime
     subcategories:


### PR DESCRIPTION
chore: Remove Terraform and Vault entries as they were changed to BSL and are not considered Opensource as commonly defined today

closes https://github.com/cncf/landscape/issues/4349