### PR TITLE
Fix Interlink project URLs in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3537,9 +3537,9 @@ landscape:
             name: Interlink
             description: >-
               InterLink aims to provide an abstraction for the execution of a Kubernetes pod on any remote resource capable of managing a Container execution lifecycle thanks to the Virtual Kubelet interface. It allows you to extend your cloud environment anywhere by running Kubernetes workloads on various infrastructures, creating a seamless cloud-native experience across diverse environments.
-            homepage_url: https://intertwin-eu.github.io/interLink/
+            homepage_url: https://interlink-project.dev
             project: sandbox
-            repo_url: https://github.com/interTwin-eu/interLink
+            repo_url: https://github.com/interlink-hq/interLink
             logo: interlink.svg
             second_path:
               - "Serverless / Installable Platform"
@@ -3547,7 +3547,7 @@ landscape:
               accepted: '2025-03-04'
               dev_stats_url: https://interlink.devstats.cncf.io/
               blog_url: https://intertwin-eu.github.io/interLink/blog/
-              github_discussions_url: https://github.com/interTwin-eu/interLink/discussions
+              github_discussions_url: https://github.com/interlink-hq/interLink/discussions
               clomonitor_name: interlink  
           - item:
             name: WasmEdge Runtime


### PR DESCRIPTION
Updated URLs for the Interlink project in landscape.yml, with the new repository and domain under CNCF

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
