### PR TITLE
chore: add lfx_slug to landscape projects

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -23,6 +23,7 @@ landscape:
             twitter: https://twitter.com/ProjectAkri
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: akri
               accepted: '2021-09-14'
               annual_review_date: '2023-06-13'
               annual_review_url: https://github.com/cncf/toc/pull/1080
@@ -55,6 +56,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             project: sandbox
             extra:
+              lfx_slug: atlantis
               accepted: '2024-06-18'
               clomonitor_name: atlantis
           - item:
@@ -80,6 +82,7 @@ landscape:
             twitter: https://twitter.com/CloudNativeFdn
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cadence
               accepted: '2025-05-22'
               clomonitor_name: cadence-workflow
               dev_stats_url: https://cadence.devstats.cncf.io/
@@ -92,6 +95,7 @@ landscape:
             logo: cdk8s.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cdk8s
               accepted: '2020-11-10'
               annual_review_url: https://github.com/cncf/toc/pull/1024
               annual_review_date: '2023-03-14'
@@ -131,6 +135,7 @@ landscape:
             logo: cloud-custodian.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: c7n
               accepted: '2020-06-25'
               dev_stats_url: https://cloudcustodian.devstats.cncf.io/
               incubating: '2022-09-14'
@@ -161,6 +166,7 @@ landscape:
             logo: devstream.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: devstream
               accepted: '2022-06-17'
               dev_stats_url: https://devstream.devstats.cncf.io/
               blog_url: https://blog.devstream.io/
@@ -211,6 +217,7 @@ landscape:
             second_path:
               - "CNAI / Agentic AI"
             extra:
+              lfx_slug: kagent
               accepted: '2025-05-22'
               dev_stats_url: https://kagent.devstats.cncf.io/
               clomonitor_name: kagent
@@ -225,6 +232,7 @@ landscape:
             twitter: https://twitter.com/Kairos_OSS
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kairos
               accepted: '2024-04-13'
               summary_personas: >-
                 Cluster admins, SREs, Cloud Architects, Platform Engineers, DevOps Engineer, DevOps practitioners, DevSecOps practitioners
@@ -262,6 +270,7 @@ landscape:
             twitter: https://twitter.com/kcl_language
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kcl
               accepted: '2023-09-20'
               dev_stats_url: https://kcl.devstats.cncf.io/
               clomonitor_name: kcl
@@ -274,6 +283,7 @@ landscape:
             logo: kitops.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kitops
               accepted: '2025-03-04'
               dev_stats_url: https://kitops.devstats.cncf.io/
               clomonitor_name: kitops
@@ -300,6 +310,7 @@ landscape:
             logo: kpt.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kpt
               accepted: '2023-06-30'
               dev_stats_url: https://kpt.devstats.cncf.io/
               clomonitor_name: kpt
@@ -332,6 +343,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             project: sandbox
             extra:
+              lfx_slug: kubean
               accepted: '2024-04-16'
               dev_stats_url: https://kubean.devstats.cncf.io/
               clomonitor_name: kubean
@@ -343,6 +355,7 @@ landscape:
             logo: kubedl.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubedl
               accepted: '2021-06-22'
               archived: '2025-03-25'
               annual_review_url: https://github.com/cncf/toc/pull/993
@@ -361,6 +374,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: kubeedge
               accepted: '2019-03-18'
               incubating: '2020-09-16'
               graduated: '2024-09-11'
@@ -445,6 +459,7 @@ landscape:
             twitter: https://twitter.com/KusionStack
             crunchbase: https://www.crunchbase.com/organization/ant-group
             extra:
+              lfx_slug: kusionstack
               accepted: '2024-09-12'
               clomonitor_name: kusionstack
           - item:
@@ -477,6 +492,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: meshery
               accepted: '2021-06-22'
               annual_review_url: https://github.com/cncf/toc/pull/1169
               annual_review_date: '2023-09-18'
@@ -510,6 +526,7 @@ landscape:
             twitter: https://twitter.com/metal3_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: metal3
               accepted: '2020-09-08'
               incubating: '2025-08-14'
               annual_review_url: https://github.com/cncf/toc/pull/958
@@ -567,6 +584,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             project: sandbox
             extra:
+              lfx_slug: opentf
               accepted: "2025-04-23"
           - item:
             name: OpenYurt
@@ -580,6 +598,7 @@ landscape:
             second_path:
               - "Wasm / Orchestration & Management"
             extra:
+              lfx_slug: openyurt
               accepted: '2020-09-08'
               incubating: '2025-01-10'
               annual_review_url: https://github.com/cncf/toc/pull/1068
@@ -614,6 +633,7 @@ landscape:
             logo: cncf.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: runme-notebooks
               accepted: '2025-01-21'
               dev_stats_url: https://runme.devstats.cncf.io/
               summary_personas: DevOps Engineers, SREs, Platform Engineers, Developers
@@ -659,6 +679,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: superedge
               accepted: '2021-09-14'
               archived: '2025-03-25'
               dev_stats_url: https://superedge.devstats.cncf.io
@@ -707,6 +728,7 @@ landscape:
             twitter: https://twitter.com/tinkerbell_oss
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: tinkerbell
               accepted: '2020-11-10'
               dev_stats_url: https://tinkerbell.devstats.cncf.io/
               youtube_url: https://www.youtube.com/channel/UCTzWInTQPvzH21KHS8jrq7A
@@ -778,6 +800,7 @@ landscape:
             logo: distribution.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cncf-distribution
               accepted: '2021-01-26'
               annual_review_url: https://github.com/cncf/toc/pull/1141
               annual_review_date: '2023-08-08'
@@ -793,6 +816,7 @@ landscape:
             twitter: https://twitter.com/dragonfly_oss
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: d7y
               accepted: '2018-11-13'
               incubating: '2020-04-09'
               graduated: '2025-10-28'
@@ -836,6 +860,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: harbor
               accepted: '2018-07-31'
               incubating: '2018-11-14'
               graduated: '2020-06-15'
@@ -913,6 +938,7 @@ landscape:
             twitter: https://twitter.com/zothub
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: zot
               accepted: '2022-12-13'
               dev_stats_url: https://zot.devstats.cncf.io/
               slack_url: https://cloud-native.slack.com/archives/C03EGRE4QGH
@@ -1002,6 +1028,7 @@ landscape:
               - repo_url: https://github.com/bank-vaults/secrets-webhook
               - repo_url: https://github.com/bank-vaults/vault-sdk
             extra:
+              lfx_slug: bank-vaults
               accepted: '2024-06-18'
               cncf_tags:
                 - https://github.com/cncf/tag-security
@@ -1059,6 +1086,7 @@ landscape:
                 branch: main
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: bpfman
               accepted: '2024-06-19'
               blog_url: https://bpfman.io/main/blog/
               slack_url: https://kubernetes.slack.com/archives/C04UJBW2553
@@ -1081,6 +1109,7 @@ landscape:
             branch: master
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cartography
               accepted: '2024-08-23'
               clomonitor_name: cartography
               dev_stats_url: https://cartography.devstats.cncf.io/
@@ -1099,6 +1128,7 @@ landscape:
             twitter: https://twitter.com/CertManager
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cert-manager
               accepted: '2020-11-10'
               incubating: '2022-09-19'
               graduated: '2024-09-29'
@@ -1166,6 +1196,8 @@ landscape:
             logo: cloudmatos.svg
             twitter: https://twitter.com/CloudMatos
             crunchbase: https://www.crunchbase.com/organization/cloudmatos
+            extra:
+                lfx_slug: matos
           - item:
             name: Confidential Containers
             description: >-
@@ -1177,6 +1209,7 @@ landscape:
             logo: confidential-containers.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: confcont
               accepted: '2022-03-08'
               dev_stats_url: https://confidentialcontainers.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/confidential-containers
@@ -1199,6 +1232,7 @@ landscape:
             logo: containerssh.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: containerssh
               accepted: '2022-09-14'
               dev_stats_url: https://containerssh.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/containerssh
@@ -1213,6 +1247,7 @@ landscape:
             logo: copa.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: copacetic
               accepted: '2023-09-19'
               dev_stats_url: https://copacetic.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/main/projects/copa
@@ -1227,6 +1262,7 @@ landscape:
             twitter: https://twitter.com/curiefense
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: curiefense
               accepted: '2021-01-26'
               archived: '2024-06-28'
               annual_review_url: https://github.com/cncf/toc/pull/806
@@ -1255,6 +1291,7 @@ landscape:
             logo: dex.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: dex
               accepted: '2020-06-25'
               annual_review_url: https://github.com/cncf/toc/pull/701
               annual_review_date: '2021-07-30'
@@ -1296,6 +1333,7 @@ landscape:
             twitter: https://twitter.com/ExtSecretsOptr
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: externalsecretsoperator
               accepted: '2022-07-26'
               dev_stats_url: https://externalsecretsoperator.devstats.cncf.io/
               clomonitor_name: external-secrets
@@ -1326,6 +1364,7 @@ landscape:
             twitter: https://twitter.com/falco_org
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: falco
               accepted: '2018-10-10'
               incubating: '2020-01-08'
               graduated: '2024-02-29'
@@ -1427,6 +1466,7 @@ landscape:
             twitter: https://twitter.com/HexaPolicy
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: hexa
               accepted: '2022-07-26'
               dev_stats_url: https://hexapolicyorchestrator.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#hexa-logos
@@ -1439,6 +1479,7 @@ landscape:
             logo: in-toto.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: intoto
               summary_personas: Security teams, Developers, Tools Groups
               summary_tags: Security, Go, Python, software supply chain
               summary_use_case: >-
@@ -1474,6 +1515,7 @@ landscape:
             twitter: https://twitter.com/keycloak
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: keycloak
               accepted: '2023-04-10'
               incubating: '2023-04-10'
               dev_stats_url: https://keycloak.devstats.cncf.io/
@@ -1517,6 +1559,7 @@ landscape:
             twitter: https://twitter.com/KeylimeProject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: keylime
               accepted: '2020-09-22'
               annual_review_url: https://github.com/cncf/toc/pull/959
               annual_review_date: '2022-11-10'
@@ -1561,6 +1604,7 @@ landscape:
             logo: kubearmor.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubearmor
               accepted: '2021-11-16'
               dev_stats_url: https://kubearmor.devstats.cncf.io/
               blog_url: https://kubearmor.io/blog
@@ -1606,6 +1650,7 @@ landscape:
             twitter: https://twitter.com/kubescape
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubescape
               accepted: '2022-12-13'
               incubating: '2025-01-13'
               slack_url: https://cloud-native.slack.com/messages/kubescape
@@ -1636,6 +1681,7 @@ landscape:
             second_path:
               - "Wasm / Embedded Functions"
             extra:
+              lfx_slug: kubewarden
               accepted: '2022-06-17'
               blog_url: https://kubewarden.io/blog
               slack_url: https://kubernetes.slack.com/
@@ -1673,6 +1719,7 @@ landscape:
             second_path:
               - "CNAI / Governance, Policy & Security"
             extra:
+              lfx_slug: kyverno
               accepted: '2020-11-10'
               incubating: '2022-07-13'
               dev_stats_url: https://kyverno.devstats.cncf.io/
@@ -1795,6 +1842,7 @@ landscape:
               - repo_url: https://github.com/oauth2-proxy/manifests
                 repo_name: manifests
             extra:
+              lfx_slug: oauth2-proxy
               accepted: '2025-10-02'
               dev_stats_url: https://oauth2-proxy.devstats.cncf.io/
               clomonitor_name: oauth2-proxy
@@ -1810,6 +1858,7 @@ landscape:
             second_path:
               - "Serverless / Embedded Functions"
             extra:
+              lfx_slug: openpolicyagent
               accepted: '2018-03-29'
               incubating: '2019-04-02'
               graduated: '2021-01-29'
@@ -1833,6 +1882,7 @@ landscape:
             twitter: https://twitter.com/openpolicyreg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: opcr
               accepted: '2022-12-13'
               artwork_url: https://github.com/opcr-io/artwork
               dev_stats_url: https://opcr.devstats.cncf.io/
@@ -1848,6 +1898,7 @@ landscape:
             twitter: https://twitter.com/OpenFGA
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openfga
               accepted: '2022-09-14'
               incubating: '2025-10-28'
               dev_stats_url: https://openfga.devstats.cncf.io/
@@ -1890,6 +1941,7 @@ landscape:
             logo: oscal-compass-color-stacked.svg
             url_for_bestpractices: https://pages.nist.gov/OSCAL/
             extra:
+              lfx_slug: trestlegrc
               accepted: '2024-06-21'
               slack_url: https://cloud-native.slack.com/archives/C06F3PEPNBW
               mailing_list_url: https://groups.google.com/g/oscal-compass
@@ -1927,6 +1979,7 @@ landscape:
             twitter: https://twitter.com/paralus_
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: paralus
               blog_url: https://www.paralus.io/blog
               accepted: '2022-12-14'
               dev_stats_url: https://paralus.devstats.cncf.io/
@@ -1941,6 +1994,7 @@ landscape:
             logo: parsec.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: parsec
               accepted: '2020-06-25'
               annual_review_url: https://github.com/cncf/toc/pull/699
               annual_review_date: '2021-07-21'
@@ -2036,6 +2090,7 @@ landscape:
             twitter: https://twitter.com/artifact_ratify
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: ratify
               accepted: '2024-08-30'
               dev_stats_url: https://ratify.devstats.cncf.io/
               clomonitor_name: ratify
@@ -2122,6 +2177,7 @@ landscape:
             twitter: https://twitter.com/slimtoolkit
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: slimtoolkit
               accepted: '2023-05-17'
               dev_stats_url: https://slimtoolkit.devstats.cncf.io/
               slack_url: https://cloud-native.slack.com/
@@ -2165,6 +2221,7 @@ landscape:
             logo: sops.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: sops
               accepted: '2023-05-17'
               clomonitor_name: sops
               dev_stats_url: https://sops.devstats.cncf.io/
@@ -2284,6 +2341,7 @@ landscape:
             logo: the-update-framework-tuf.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: tuf
               summary_personas: Security teams, Repository administrators, Registry administrators
               summary_tags: Security, Go, Python, Rust, JavaScript, CLI
               summary_use_case: >-
@@ -2336,6 +2394,7 @@ landscape:
             logo: tokenetes.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: tratteria
               accepted: '2025-01-21'
               dev_stats_url: https://tokenetes.devstats.cncf.io/
           - item:
@@ -2420,6 +2479,7 @@ landscape:
             twitter: https://twitter.com/athenzio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: athenz
               accepted: '2021-01-26'
               annual_review_url: https://github.com/cncf/toc/pull/1106
               annual_review_date: '2023-06-30'
@@ -2462,6 +2522,7 @@ landscape:
             twitter: https://twitter.com/spiffeio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: spiffe
               accepted: '2018-03-29'
               incubating: '2020-06-22'
               graduated: '2022-08-23'
@@ -2550,6 +2611,7 @@ landscape:
             twitter: https://twitter.com/spiffeio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: spire
               accepted: '2018-03-29'
               incubating: '2020-06-22'
               graduated: '2022-08-22'
@@ -2575,6 +2637,7 @@ landscape:
             logo: teller.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: teller
               accepted: '2022-04-26'
               mailing_list_url: https://github.com/tellerops/teller/discussions
               clomonitor_name: teller
@@ -2659,6 +2722,7 @@ landscape:
             logo: carina.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: carina
               accepted: '2022-12-14'
               dev_stats_url: https://carina.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#carina-logos
@@ -2698,6 +2762,7 @@ landscape:
             twitter: https://twitter.com/ChubaoFS
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: chubaofs
               accepted: '2019-12-16'
               incubating: '2022-07-03'
               graduated: '2024-12-11'
@@ -2727,6 +2792,7 @@ landscape:
             logo: curve.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: curve
               accepted: '2022-06-17'
               archived: '2024-10-26'
               clomonitor_name: curve
@@ -2819,6 +2885,7 @@ landscape:
             twitter: https://twitter.com/daocloud_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: hwameistor
               blog_url: https://hwameistor.io/blog
               accepted: '2023-06-22'
               dev_stats_url: https://hwameistor.devstats.cncf.io/
@@ -2875,6 +2942,7 @@ landscape:
             logo: k8up.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: k8up
               accepted: '2021-11-16'
               annual_review_url: https://github.com/cncf/toc/pull/1067
               annual_review_date: '2023-06-01'
@@ -2890,6 +2958,7 @@ landscape:
             logo: kanister.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kanister
               accepted: '2023-09-20'
               dev_stats_url: https://kanister.devstats.cncf.io/
               clomonitor_name: kanister
@@ -2919,6 +2988,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             joined: '2019-10-11'
             extra:
+              lfx_slug: longhorn
               accepted: '2019-10-11'
               incubating: '2021-11-04'
               dev_stats_url: https://longhorn.devstats.cncf.io/
@@ -2993,6 +3063,7 @@ landscape:
             twitter: https://twitter.com/openebs
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openebs
               accepted: '2024-10-10'
               annual_review_url: https://github.com/cncf/toc/pull/685
               annual_review_date: '2021-07-06'
@@ -3016,6 +3087,7 @@ landscape:
             twitter: https://twitter.com/orasproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: oras
               accepted: '2021-07-13'
               annual_review_url: https://github.com/cncf/toc/pull/943
               annual_review_date: '2022-10-14'
@@ -3037,6 +3109,7 @@ landscape:
             logo: piraeus.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: piraeus-datastore
               accepted: '2021-01-26'
               annual_review_url: https://github.com/cncf/toc/pull/839
               annual_review_date: '2022-05-16'
@@ -3087,6 +3160,7 @@ landscape:
             twitter: https://twitter.com/rook_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: rook
               accepted: '2018-01-29'
               incubating: '2018-09-25'
               graduated: '2020-10-07'
@@ -3203,6 +3277,7 @@ landscape:
             enduser: true
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: vineyard
               accepted: '2021-04-28'
               annual_review_url: https://github.com/cncf/toc/pull/874
               annual_review_date: '2022-07-11'
@@ -3252,6 +3327,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: containerd
               accepted: '2017-03-29'
               incubating: '2017-03-29'
               graduated: '2019-02-28'
@@ -3287,6 +3363,7 @@ landscape:
             logo: cncf.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: composefs
               accepted: '2025-01-21'
               dev_stats_url: https://composefs.devstats.cncf.io/
           - item:
@@ -3299,6 +3376,7 @@ landscape:
             logo: cncf.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: bootc
               accepted: '2025-01-21'
               dev_stats_url: https://bootc.devstats.cncf.io
           - item:
@@ -3310,6 +3388,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: cri-o
               accepted: '2019-04-08'
               incubating: '2019-04-08'
               graduated: '2023-07-19'
@@ -3348,6 +3427,7 @@ landscape:
             logo: hyperlight.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: hyperlight
               accepted: '2025-03-04'
               dev_stats_url: https://hyperlight.devstats.cncf.io/
           - item:
@@ -3371,6 +3451,7 @@ landscape:
             logo: inclavare.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: inclavarecontainers
               accepted: '2021-09-14'
               annual_review_url: https://github.com/cncf/toc/pull/957
               annual_review_date: '2022-11-06'
@@ -3402,6 +3483,7 @@ landscape:
             second_path:
               - "Wasm / Runtimes"
             extra:
+              lfx_slug: krustlet
               accepted: '2021-07-13'
               archived: '2024-09-30'
           - item:
@@ -3415,6 +3497,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/huawei-cloud
             allow_duplicate_repo: true
             extra:
+              lfx_slug: kuasar
               accepted: '2023-12-19'
               youtube_url: https://www.youtube.com/channel/UCm796d5_CMipZGrdFskbp2g
               slack_url: https://slack.cncf.io/
@@ -3429,6 +3512,7 @@ landscape:
             logo: lima.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: lima
               accepted: '2022-09-14'
               incubating: '2025-10-14'
               dev_stats_url: https://lima.devstats.cncf.io/
@@ -3446,6 +3530,7 @@ landscape:
             project: sandbox
             logo: podman.svg
             extra:
+              lfx_slug: podman-container-tools
               accepted: '2025-01-21'
               dev_stats_url: https://podman.devstats.cncf.io/
               clomonitor_name: podman
@@ -3463,6 +3548,7 @@ landscape:
             logo: rkt.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: rkt
               accepted: '2017-03-29'
               archived: '2019-08-16'
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/archived.md#rkt-logos
@@ -3514,6 +3600,7 @@ landscape:
             logo: urunc.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: urunc
               accepted: '2025-05-22'
               dev_stats_url: https://urunc.devstats.cncf.io/
               slack_url: https://slack.cncf.io/
@@ -3529,6 +3616,7 @@ landscape:
             second_path:
               - "Serverless / Installable Platform"
             extra:
+              lfx_slug: virtualkubelet
               accepted: '2018-12-04'
               dev_stats_url: https://virtualkubelet.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#virtual-kubelet-logos
@@ -3546,6 +3634,7 @@ landscape:
             second_path:
               - "Serverless / Installable Platform"
             extra:
+              lfx_slug: interlink
               accepted: '2025-03-04'
               dev_stats_url: https://interlink.devstats.cncf.io/
               blog_url: https://intertwin-eu.github.io/interLink/blog/
@@ -3565,6 +3654,7 @@ landscape:
               - "Wasm / Application Frameworks"
               - "CNAI / ML Serving"
             extra:
+              lfx_slug: wasmedge-runtime
               accepted: '2021-04-28'
               annual_review_url: https://github.com/cncf/toc/pull/1109
               annual_review_date: '2023-07-04'
@@ -3614,6 +3704,7 @@ landscape:
             twitter: https://twitter.com/projectantrea
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: antrea
               accepted: '2021-04-28'
               annual_review_url: https://github.com/cncf/toc/pull/871
               annual_review_date: '2022-07-07'
@@ -3638,6 +3729,7 @@ landscape:
             twitter: https://twitter.com/ciliumproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cilium
               accepted: '2021-10-13'
               incubating: '2021-10-13'
               graduated: '2023-10-11'
@@ -3679,6 +3771,7 @@ landscape:
             logo: cni-genie.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cni-genie
               accepted: '2020-06-25'
               annual_review_url: https://github.com/cncf/toc/pull/863
               annual_review_date: '2022-06-21'
@@ -3692,6 +3785,7 @@ landscape:
             logo: container-network-interface-cni.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cni
               accepted: '2017-05-23'
               incubating: '2017-05-23'
               dev_stats_url: https://cni.devstats.cncf.io/
@@ -3721,6 +3815,7 @@ landscape:
             logo: fabedge.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: fabedge
               accepted: '2022-03-08'
               archived: '2024-11-05'
               annual_review_url: https://github.com/cncf/toc/pull/1088
@@ -3767,6 +3862,7 @@ landscape:
             twitter: https://twitter.com/KubeOvn
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kube-ovn
               accepted: '2021-01-26'
               annual_review_url: https://github.com/cncf/toc/pull/1112
               annual_review_date: '2023-07-10'
@@ -3786,6 +3882,7 @@ landscape:
             logo: kubevip.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kube-vip
               accepted: '2021-06-26'
               dev_stats_url: https://kubevip.devstats.cncf.io/
               clomonitor_name: kube-vip
@@ -3811,6 +3908,7 @@ landscape:
             twitter: https://twitter.com/nservicemesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: nsm
               accepted: '2019-04-11'
               annual_review_url: https://github.com/cncf/toc/pull/792
               annual_review_date: '2022-02-28'
@@ -3839,6 +3937,7 @@ landscape:
             logo: ovn-kubernetes.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: ovn-kubernetes
               accepted: '2024-10-17'
               dev_stats_url: https://ovn-kubernetes.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#ovn-kubernetes-logos
@@ -3873,6 +3972,7 @@ landscape:
             twitter: https://twitter.com/daocloud_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: spiderpool
               accepted: '2023-12-19'
               dev_stats_url: https://spiderpool.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/master/projects/spiderpool
@@ -3888,6 +3988,7 @@ landscape:
             twitter: https://twitter.com/submarinerio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: submariner
               accepted: '2021-04-28'
               clomonitor_name: submariner
               annual_review_url: https://github.com/cncf/toc/pull/1115
@@ -3939,6 +4040,7 @@ landscape:
             second_path:
               - "CNAI / General Orchestration"
             extra:
+              lfx_slug: armada
               accepted: '2022-07-25'
               dev_stats_url: https://armada.devstats.cncf.io/
               slack_url: http://slack.cncf.io/
@@ -3962,6 +4064,7 @@ landscape:
             twitter: https://twitter.com/clastixio
             crunchbase: https://www.crunchbase.com/organization/clastix
             extra:
+              lfx_slug: capsule
               accepted: '2022-12-13'
               clomonitor_name: capsule
               dev_stats_url: https://capsule.devstats.cncf.io/
@@ -4002,6 +4105,7 @@ landscape:
             logo: clusternet.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: clusternet
               accepted: '2023-03-07'
               dev_stats_url: https://clusternet.devstats.cncf.io/
               slack_url: https://cloud-native.slack.com/messages/clusternet
@@ -4017,6 +4121,7 @@ landscape:
             logo: clusterpedia.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: clusterpedia
               accepted: '2022-06-17'
               dev_stats_url: https://clusterpedia.devstats.cncf.io/
               slack_url: https://cloud-native.slack.com/messages/clusterpedia
@@ -4036,6 +4141,7 @@ landscape:
             twitter: https://twitter.com/crossplane_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: crossplane
               accepted: '2020-06-25'
               incubating: '2021-09-14'
               graduated: '2025-10-28'
@@ -4089,6 +4195,7 @@ landscape:
             logo: eraser.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: eraser
               accepted: '2023-06-30'
               dev_stats_url: https://eraser.devstats.cncf.io/
               clomonitor_name: eraser
@@ -4119,6 +4226,7 @@ landscape:
             second_path:
               - "CNAI / General Orchestration"
             extra:
+              lfx_slug: hami
               accepted: '2024-08-21'
               clomonitor_name: hami
           - item:
@@ -4140,6 +4248,7 @@ landscape:
             twitter: https://x.com/karmada_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: karmada
               accepted: '2021-09-14'
               incubating: '2023-12-12'
               annual_review_url: https://github.com/cncf/toc/pull/954
@@ -4176,6 +4285,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: kcp
               chat_channel: '#kcp-dev'
               slack_url: http://slack.k8s.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kcp-logos
@@ -4198,6 +4308,7 @@ landscape:
             second_path:
               - "Platform / Certified Kubernetes - Distribution"
             extra:
+              lfx_slug: k0s
               chat_channel: '#k0s-dev'
               slack_url: http://slack.k8s.io/
               blog_url: https://medium.com/k0sproject
@@ -4230,6 +4341,7 @@ landscape:
             second_path:
               - "Serverless / Installable Platform"
             extra:
+              lfx_slug: KEDA
               accepted: '2020-03-12'
               incubating: '2021-08-18'
               graduated: '2023-08-22'
@@ -4275,6 +4387,7 @@ landscape:
               - "Serverless / Installable Platform"
               - "Wasm / Embedded Functions"
             extra:
+              lfx_slug: knative
               accepted: '2022-03-02'
               incubating: '2022-03-02'
               graduated: '2025-09-11'
@@ -4316,6 +4429,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/alibaba-cloud
             project: sandbox
             extra:
+              lfx_slug: koordinator
               accepted: '2024-04-16'
               clomonitor_name: koordinator
           - item:
@@ -4337,6 +4451,7 @@ landscape:
             logo: kube-rs.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kube-rs
               accepted: '2021-11-16'
               dev_stats_url: https://kubers.devstats.cncf.io/
               slack_url: https://discord.gg/tokio
@@ -4369,6 +4484,7 @@ landscape:
             twitter: https://twitter.com/kubeflow
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubeflow
               accepted: '2023-07-25'
               incubating: '2023-07-25'
               blog_url: https://blog.kubeflow.org
@@ -4392,6 +4508,7 @@ landscape:
             logo: kubefleet.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubefleet
               accepted: '2025-01-21'
               slack_url: http://slack.cncf.io/
               summary_personas: Platform Engineers, DevOps Engineers, Kubernetes Administrators
@@ -4416,6 +4533,7 @@ landscape:
               - "Wasm / Orchestration & Management"
               - "CNAI / General Orchestration"
             extra:
+              lfx_slug: k8s
               accepted: '2016-03-10'
               incubating: '2016-03-10'
               graduated: '2018-03-06'
@@ -4448,6 +4566,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: kubeslice
               chat_channel: '#kubeslice'
               slack_url: http://slack.k8s.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kubeslice-logos
@@ -4468,6 +4587,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: kubestellar
               chat_channel: '#kubestellar-dev'
               slack_url: http://slack.k8s.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kubestellar-logos
@@ -4488,6 +4608,7 @@ landscape:
             twitter: https://twitter.com/kubereboot
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kured
               accepted: '2022-09-14'
               dev_stats_url: https://kured.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kured-logos
@@ -4519,6 +4640,7 @@ landscape:
             twitter: https://twitter.com/ocm_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openclustermanagement
               accepted: '2021-11-09'
               annual_review_url: https://github.com/cncf/toc/pull/982
               annual_review_date: '2022-12-14'
@@ -4540,6 +4662,7 @@ landscape:
               - "Serverless / Installable Platforms"
               - "Wasm / Embedded Functions"
             extra:
+              lfx_slug: openfunction
               accepted: '2022-04-26'
               dev_stats_url: https://openfunction.devstats.cncf.io/
               blog_url: https://openfunction.dev/blog/
@@ -4584,6 +4707,7 @@ landscape:
             second_path:
               - "Serverless / Tools"
             extra:
+              lfx_slug: serverlessdevs
               accepted: '2022-09-14'
               clomonitor_name: serverless-devs
           - item:
@@ -4610,6 +4734,7 @@ landscape:
             second_path:
               - "CNAI / General Orchestration"
             extra:
+              lfx_slug: Volcano
               accepted: '2020-04-09'
               dev_stats_url: https://volcano.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#volcano
@@ -4630,6 +4755,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: wasmcloud
               accepted: '2021-07-13'
               incubating: '2024-11-08'
               devstats: https://wasmcloud.devstats.cncf.io/
@@ -4671,6 +4797,7 @@ landscape:
             twitter: https://twitter.com/corednsio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: coredns
               accepted: '2017-02-27'
               incubating: '2018-02-26'
               graduated: '2019-01-24'
@@ -4696,6 +4823,7 @@ landscape:
             twitter: https://twitter.com/etcdio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: etcd
               accepted: '2018-12-11'
               incubating: '2018-12-11'
               graduated: '2020-11-24'
@@ -4737,6 +4865,7 @@ landscape:
             logo: k8gb.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: k8gb
               accepted: '2021-03-30'
               annual_review_url: https://github.com/cncf/toc/pull/837
               annual_review_date: '2022-05-11'
@@ -4790,6 +4919,7 @@ landscape:
               - repo_url: https://github.com/oxia-db/oxia-client-java
                 repo_name: oxia-client-java
             extra:
+              lfx_slug: oxia
               accepted: '2025-10-06'
               dev_stats_url: https://oxia.devstats.cncf.io/
               clomonitor_name: oxia
@@ -4802,6 +4932,7 @@ landscape:
             logo: xline.svg
             crunchbase: https://www.crunchbase.com/organization/beijing-datenlord-technology
             extra:
+              lfx_slug: xline
               accepted: '2023-06-30'
               archived: '2025-09-19'
               clomonitor_name: xline
@@ -4872,6 +5003,7 @@ landscape:
             twitter: https://twitter.com/grpcio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: grpc
               accepted: '2017-02-16'
               incubating: '2017-02-16'
               dev_stats_url: https://grpc.devstats.cncf.io/
@@ -4897,6 +5029,7 @@ landscape:
             twitter: https://twitter.com/connectrpc
             crunchbase: https://www.crunchbase.com/organization/buf-technologies
             extra:
+              lfx_slug: connect
               accepted: '2024-04-13'
               dev_stats_url: https://connect.devstats.cncf.io
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#connect-rpc-logos
@@ -4953,6 +5086,7 @@ landscape:
             twitter: https://twitter.com/BfeNetworks
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: BFE
               accepted: '2020-06-25'
               annual_review_url: https://github.com/cncf/toc/pull/1066
               annual_review_date: '2023-06-01'
@@ -4984,6 +5118,7 @@ landscape:
             twitter: https://twitter.com/projectcontour
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: contour
               accepted: '2020-07-07'
               incubating: '2020-07-07'
               dev_stats_url: https://contour.devstats.cncf.io/
@@ -5004,6 +5139,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: envoy
               accepted: '2017-09-13'
               incubating: '2017-09-13'
               graduated: '2018-11-28'
@@ -5048,6 +5184,7 @@ landscape:
             project: sandbox
             description: eBPF based cloud-native load-balancer. Powering Kubernetes|Edge|5G|IoT|XaaS Apps.
             extra:
+              lfx_slug: loxilb
               accepted: '2024-08-30'
               slack_url: https://kubernetes.slack.com/messages/loxilb
               chat_channel: '#loxilb'
@@ -5061,6 +5198,7 @@ landscape:
             logo: metallb.svg
             crunchbase: https://www.crunchbase.com/organization/metallb
             extra:
+              lfx_slug: metallb
               accepted: '2021-09-14'
               annual_review_url: https://github.com/cncf/toc/pull/942
               annual_review_date: '2022-10-12'
@@ -5096,6 +5234,7 @@ landscape:
             logo: openelb-io.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openelb
               accepted: '2021-11-09'
               slack_url: https://kubernetes.slack.com/messages/openelb
               chat_channel: '#openelb'
@@ -5216,6 +5355,7 @@ landscape:
             twitter: https://twitter.com/megaease
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: easegress
               accepted: '2023-12-19'
               clomonitor_name: easegress
           - item:
@@ -5226,6 +5366,7 @@ landscape:
             logo: emissary-ingress.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: emissary
               accepted: '2021-04-13'
               incubating: '2021-04-13'
               dev_stats_url: https://emissaryingress.devstats.cncf.io/
@@ -5291,6 +5432,7 @@ landscape:
             repo_url: https://github.com/kgateway-dev/kgateway
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kgateway
               accepted: '2025-03-04'
               blog_url: https://kgateway.dev/blog
               summary_personas: Platform Engineers, DevOps Engineers, SREs, API Managers
@@ -5325,6 +5467,7 @@ landscape:
               and application developers to easily connect, secure, and protect their services and infrastructure across multiple clusters 
               with policies for TLS, DNS, application authentication & authorization, and rate limiting.
             extra:
+              lfx_slug: kuadrant
               accepted: '2024-06-19'
               clomonitor_name: kuadrant
           - item:
@@ -5403,6 +5546,7 @@ landscape:
             logo: aeraki-mesh.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: aerakimesh
               accepted: '2022-06-17'
               annual_review_url: https://github.com/cncf/toc/pull/1143
               annual_review_date: '2023-08-14'
@@ -5481,6 +5625,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
             extra:
+              lfx_slug: istio
               accepted: '2022-09-30'
               incubating: '2022-09-30'
               graduated: '2023-07-12'
@@ -5514,6 +5659,7 @@ landscape:
             twitter: https://twitter.com/Kmesh_net
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kmesh
               accepted: '2024-10-17'
               youtube_url: https://www.youtube.com/channel/UC-ToQ9h0SR_w492PpIfZAGw
               slack_url: https://slack.cncf.io/
@@ -5528,6 +5674,7 @@ landscape:
             twitter: https://twitter.com/KumaMesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kuma
               accepted: '2020-06-25'
               annual_review_url: https://github.com/cncf/toc/pull/1078
               annual_review_date: '2023-06-10'
@@ -5558,6 +5705,7 @@ landscape:
             twitter: https://twitter.com/linkerd
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: linkerd
               accepted: '2017-01-23'
               incubating: '2018-04-06'
               graduated: '2021-07-28'
@@ -5597,6 +5745,7 @@ landscape:
             logo: merbridge.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: merbridge
               blog_url: https://merbridge.io/blog/
               accepted: '2022-12-14'
               dev_stats_url: https://merbridge.devstats.cncf.io/
@@ -5612,6 +5761,7 @@ landscape:
             twitter: https://twitter.com/openservicemesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: OSM
               accepted: '2020-09-08'
               archived: '2023-06-30'
               annual_review_url: https://github.com/cncf/toc/pull/742
@@ -5636,6 +5786,7 @@ landscape:
             open_source: true
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: sermant
               accepted: '2024-10-09'  
               clomonitor_name: sermant
           - item:
@@ -5647,6 +5798,7 @@ landscape:
             twitter: https://twitter.com/smi_spec
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: smi
               accepted: '2020-03-19'
               archived: '2023-09-25'
               annual_review_url: https://github.com/cncf/toc/pull/833
@@ -5660,6 +5812,7 @@ landscape:
             twitter: https://twitter.com/smp_spec
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: service-mesh-performance
               accepted: '2021-06-22'
               archived: '2025-09-16'
               dev_stats_url: https://servicemeshperformance.devstats.cncf.io/
@@ -5760,6 +5913,7 @@ landscape:
             joined: "2025-01-21"
             twitter: https://x.com/CloudNativePg
             extra:
+              lfx_slug: cloudnativepg
               accepted: "2025-01-21"
               summary_personas: Developers, Platform Engineers, PostgreSQL Administrators, DBAs
               summary_tags: PostgreSQL,Postgres,RDBMS,Database,Transactional Database,Microservice Database,OLTP,AI/ML
@@ -6002,6 +6156,7 @@ landscape:
             logo: opengemini.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: opengemini
               accepted: '2024-07-09'
               slack_url: https://cloud-native.slack.com/messages/open-gemini
               clomonitor_name: opengemini
@@ -6091,6 +6246,7 @@ landscape:
             logo: schemahero.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: schemahero
               accepted: '2020-11-10'
               annual_review_url: https://github.com/cncf/toc/pull/771
               annual_review_date: '2021-12-22'
@@ -6212,6 +6368,7 @@ landscape:
             twitter: https://twitter.com/tikvproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: tikv
               accepted: '2018-08-28'
               incubating: '2018-08-28'
               graduated: '2020-09-02'
@@ -6321,6 +6478,7 @@ landscape:
             twitter: https://twitter.com/vitessio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: vitess
               accepted: '2018-02-05'
               incubating: '2018-02-05'
               graduated: '2019-11-05'
@@ -6495,6 +6653,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             joined: '2018-05-15'
             extra:
+              lfx_slug: cloudevents
               accepted: '2018-05-15'
               incubating: '2019-10-24'
               graduated: '2024-01-25'
@@ -6540,6 +6699,7 @@ landscape:
             repo_url: http://github.com/drasi-project/drasi-platform
             project: sandbox
             extra:
+              lfx_slug: drasi
               accepted: '2025-01-21'
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             logo: drasi.svg
@@ -6633,6 +6793,7 @@ landscape:
             twitter: https://twitter.com/nats_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: nats
               accepted: '2018-03-15'
               incubating: '2018-03-15'
               dev_stats_url: https://nats.devstats.cncf.io/
@@ -6690,6 +6851,7 @@ landscape:
             twitter: https://twitter.com/PravegaIO
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: pravega
               accepted: '2020-11-10'
               archived: "2025-09-23"
               annual_review_url: https://github.com/cncf/toc/pull/775
@@ -6745,6 +6907,7 @@ landscape:
             twitter: https://twitter.com/strimziio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: strimzi
               accepted: '2019-08-28'
               incubating: '2024-02-08'
               annual_review_url: https://github.com/cncf/toc/pull/939
@@ -6774,6 +6937,7 @@ landscape:
             twitter: https://twitter.com/TremorDEBS
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: tremor
               accepted: '2020-09-08'
               annual_review_url: https://github.com/cncf/toc/pull/949
               annual_review_date: '2022-10-19'
@@ -6834,6 +6998,7 @@ landscape:
             twitter: https://twitter.com/cncfartifacthub
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: artifact-hub
               accepted: '2020-06-25'
               incubating: '2024-05-30'
               annual_review_url: https://github.com/cncf/toc/pull/681
@@ -6849,6 +7014,7 @@ landscape:
             logo: backstage.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: backstage
               accepted: '2020-09-08'
               incubating: '2022-03-15'
               dev_stats_url: https://backstage.devstats.cncf.io/
@@ -6877,6 +7043,7 @@ landscape:
             twitter: https://twitter.com/buildpacks_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: buildpacks
               accepted: '2018-10-03'
               incubating: '2020-11-18'
               dev_stats_url: https://buildpacks.devstats.cncf.io/
@@ -6895,6 +7062,7 @@ landscape:
             twitter: https://twitter.com/carvel_dev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: carvel
               accepted: '2022-09-14'
               clomonitor_name: carvel
               dev_stats_url: https://carvel.devstats.cncf.io/
@@ -6966,6 +7134,7 @@ landscape:
             logo: dalec.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: dalec
               accepted: '2025-10-08'
               dev_stats_url: https://dalec.devstats.cncf.io/
               clomonitor_name: dalec
@@ -6982,6 +7151,7 @@ landscape:
               - "Wasm / Embedded Functions"
               - "Serverless / Framework"
             extra:
+              lfx_slug: dapr
               accepted: '2021-11-09'
               incubating: '2021-11-09'
               graduated: '2024-10-30'
@@ -7044,6 +7214,7 @@ landscape:
             logo: devfile.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: devfile
               accepted: '2022-01-11'
               slack_url: https://kubernetes.slack.com/messages/devfile
               chat_channel: '#devfile'
@@ -7058,6 +7229,7 @@ landscape:
             twitter: https://twitter.com/DevSpace
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: devspace
               accepted: '2022-12-13'
               slack_url: https://kubernetes.slack.com/messages/devspace
               chat_channel: '#devspace'
@@ -7134,6 +7306,7 @@ landscape:
             twitter: https://twitter.com/helmpack
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: helm
               accepted: '2018-06-01'
               incubating: '2018-06-01'
               graduated: '2020-05-01'
@@ -7205,6 +7378,7 @@ landscape:
             logo: Ko.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: ko
               accepted: '2022-12-14'
               dev_stats_url: https://ko.devstats.cncf.io/
               slack_url: https://slack.k8s.io
@@ -7219,6 +7393,7 @@ landscape:
             twitter: https://twitter.com/Konveyor_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: konveyor
               accepted: '2022-07-26'
               dev_stats_url: https://konveyor.devstats.cncf.io/
               slack_url: https://slack.k8s.io
@@ -7248,6 +7423,7 @@ landscape:
             logo: krator.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: krator
               accepted: '2021-07-13'
               archived: '2024-01-31'
               dev_stats_url: https://krator.devstats.cncf.io/
@@ -7276,6 +7452,7 @@ landscape:
             twitter: https://twitter.com/oam_dev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubevela
               accepted: '2021-06-22'
               incubating: '2023-02-27'
               annual_review_url: https://github.com/cncf/toc/pull/838
@@ -7307,6 +7484,7 @@ landscape:
             twitter: https://twitter.com/kubevirt
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubevirt
               accepted: '2019-09-06'
               incubating: '2022-04-19'
               dev_stats_url: https://kubevirt.devstats.cncf.io/
@@ -7340,6 +7518,7 @@ landscape:
             twitter: https://twitter.com/kudobuilder
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kudo
               accepted: '2020-06-25'
               dev_stats_url: https://kudo.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#kudo
@@ -7358,6 +7537,8 @@ landscape:
             repo_url: https://github.com/uselagoon/lagoon
             logo: lagoon.svg
             crunchbase: https://www.crunchbase.com/organization/amazee-io
+            extra:
+              lfx_slug: lagoon
           - item:
             name: Mia-Platform
             description: >-
@@ -7383,6 +7564,7 @@ landscape:
             twitter: https://twitter.com/microcksio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: microcks
               accepted: '2023-06-22'
               dev_stats_url: https://microcks.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#microcks-logos
@@ -7425,6 +7607,7 @@ landscape:
             repo_url: https://github.com/modelpack/model-spec
             logo: cncf.svg
             extra:
+              lfx_slug: modelpack
               accepted: '2025-05-13'
           - item:
             name: Monokle
@@ -7446,6 +7629,7 @@ landscape:
             logo: nocalhost.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: nocalhost
               accepted: '2021-11-16'
               archived: '2025-03-25'
               dev_stats_url: https://nocalhost.devstats.cncf.io/
@@ -7496,6 +7680,7 @@ landscape:
             logo: operator-framework.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: operator-sdk
               accepted: '2020-07-09'
               incubating: '2020-07-09'
               dev_stats_url: https://operatorframework.devstats.cncf.io/
@@ -7524,6 +7709,7 @@ landscape:
             logo: podman-desktop.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: podman-desktop
               accepted: '2025-01-21'
               dev_stats_url: https://podmandesktop.devstats.cncf.io/
               clomonitor_name: podman-desktop
@@ -7547,6 +7733,7 @@ landscape:
             twitter: https://twitter.com/get_porter
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: porter
               accepted: '2020-09-08'
               annual_review_url: https://github.com/cncf/toc/pull/951
               annual_review_date: '2022-10-25'
@@ -7583,6 +7770,7 @@ landscape:
             logo: radius.svg
             twitter: https://twitter.com/radapp_io
             extra:
+              lfx_slug: radius
               accepted: '2024-04-16'
               blog_url: https://blog.radapp.io/posts
               youtube_url: https://www.youtube.com/@radapp_io
@@ -7601,6 +7789,7 @@ landscape:
             repo_url: https://github.com/score-spec/spec
             project: sandbox
             extra:
+              lfx_slug: score
               accepted: '2024-07-08'
               linkedin_url: https://www.linkedin.com/company/score-dev
               blog_url: https://score.dev/blog
@@ -7618,6 +7807,7 @@ landscape:
             twitter: https://twitter.com/sealer_oss
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: sealer
               accepted: '2022-04-26'
               annual_review_url: https://github.com/cncf/toc/pull/1041
               annual_review_date: '2023-04-26'
@@ -7633,6 +7823,7 @@ landscape:
             twitter: https://twitter.com/CNCFWorkflow
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: serverlessworkflow
               accepted: '2020-07-14'
               annual_review_url: https://github.com/cncf/toc/pull/1099
               annual_review_date: '2023-06-27'
@@ -7654,6 +7845,7 @@ landscape:
             twitter: https://twitter.com/shipwrightio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: shipwright
               accepted: '2024-08-19'
               clomonitor_name: shipwright
           - item:
@@ -7677,6 +7869,7 @@ landscape:
             logo: stacker.svg
             project: sandbox
             extra:
+              lfx_slug: stacker
               accepted: '2024-06-19'
               clomonitor_name: stacker
           - item:
@@ -7697,6 +7890,7 @@ landscape:
             twitter: https://twitter.com/telepresenceio
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: telepresence
               accepted: '2018-05-15'
               annual_review_url: https://github.com/cncf/toc/pull/872
               annual_review_date: '2022-07-08'
@@ -7732,6 +7926,7 @@ landscape:
             logo: vscodek8stools.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: vscodekubernetestools
               accepted: '2021-11-09'
               dev_stats_url: https://vscodek8stools.devstats.cncf.io/
               clomonitor_name: vscode-kubernetes-tools
@@ -7756,6 +7951,7 @@ landscape:
               - repo_url: https://github.com/xregistry/spec
               - repo_url: https://github.com/xregistry/xregistry.github.io
             extra:
+              lfx_slug: xregistry
               accepted: '2025-06-05'
               dev_stats_url: https://xregistry.devstats.cncf.io/
               clomonitor_name: xregistry
@@ -7809,6 +8005,7 @@ landscape:
             twitter: https://twitter.com/argoproj
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: argo
               accepted: '2020-03-26'
               incubating: '2020-03-26'
               graduated: '2022-12-06'
@@ -7874,6 +8071,7 @@ landscape:
             twitter: https://twitter.com/brigadecore
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: brigade
               accepted: '2019-03-18'
               archived: '2022-10-19'
               artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox.md#brigade-logos
@@ -7975,6 +8173,7 @@ landscape:
             twitter: https://twitter.com/fluxcd
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: fluxcd
               accepted: '2019-07-15'
               incubating: '2021-03-12'
               graduated: '2022-11-30'
@@ -8124,6 +8323,7 @@ landscape:
             twitter: https://twitter.com/keptnproject
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: keptn
               accepted: '2020-06-25'
               incubating: '2022-07-13'
               archived: '2025-09-03'
@@ -8192,6 +8392,7 @@ landscape:
             twitter: https://twitter.com/opengitops
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: gitops-wg
               accepted: '2021-01-26'
               clomonitor_name: open-gitops
           - item:
@@ -8202,6 +8403,7 @@ landscape:
             logo: OpenKruise.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openkruise
               accepted: '2020-11-10'
               annual_review_url: https://github.com/cncf/toc/pull/767
               annual_review_date: '2021-12-14'
@@ -8235,6 +8437,7 @@ landscape:
             twitter: https://twitter.com/pipecd_dev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: pipecd
               accepted: '2023-05-17'
               dev_stats_url: https://pipecd.devstats.cncf.io/
               slack_url: https://cloud-native.slack.com/messages/pipecd
@@ -8330,6 +8533,7 @@ landscape:
             twitter: https://twitter.com/werf_io
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: werf
               accepted: '2022-12-13'
               dev_stats_url: https://werf.devstats.cncf.io/
               blog_url: https://blog.werf.io
@@ -8354,6 +8558,7 @@ landscape:
             logo: kube-burner.svg
             crunchbase: https://www.crunchbase.com/organization/red-hat
             extra:
+              lfx_slug: kube-burner
               accepted: '2023-12-18'
               dev_stats_url: https://kubeburner.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/tree/main/projects/kube-burner
@@ -8562,6 +8767,7 @@ landscape:
             second_path:
               - "Wasm / Edge/Bare metal"
             extra:
+              lfx_slug: flatcar
               accepted: '2024-08-02'
               incubating: '2024-08-02'
               clomonitor_name: flatcar
@@ -8630,6 +8836,7 @@ landscape:
             logo: k3s.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: k3s
               accepted: '2020-08-19'
               annual_review_url: https://github.com/cncf/toc/pull/955
               annual_review_date: '2022-11-04'
@@ -9377,6 +9584,7 @@ landscape:
             logo: kubeclipper.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kubeclipper
               accepted: '2023-06-30'
               clomonitor_name: kubeclipper
               dev_stats_url: https://kubeclipper.devstats.cncf.io/
@@ -9522,6 +9730,7 @@ landscape:
             second_path:
               - "CNAI / General Orchestration"
             extra:
+              lfx_slug: cozystack
               accepted: '2025-03-04'
               dev_stats_url: https://cozystack.devstats.cncf.io/
               summary_business_use_case: >-
@@ -10055,6 +10264,7 @@ landscape:
             homepage_url: https://github.com/SlimPlanet/SlimFaas
             project: sandbox
             extra:
+              lfx_slug: slimfaas
               accepted: '2025-01-21'
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             logo: slimfaas.svg
@@ -10155,6 +10365,7 @@ landscape:
             twitter: https://twitter.com/openfeature
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openfeature
               accepted: '2022-06-17'
               incubating: '2023-11-21'
               dev_stats_url: https://openfeature.devstats.cncf.io/
@@ -10195,6 +10406,7 @@ landscape:
             twitter: https://twitter.com/chaos_mesh
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: ChaosMesh
               accepted: '2020-07-14'
               incubating: '2022-02-16'
               annual_review_url: https://github.com/cncf/toc/pull/944
@@ -10221,6 +10433,7 @@ landscape:
             twitter: https://twitter.com/ChaosbladeI
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: chaosblade
               accepted: '2021-04-28'
               annual_review_url: https://github.com/cncf/toc/pull/995
               annual_review_date: '2023-01-13'
@@ -10246,6 +10459,7 @@ landscape:
             twitter: https://twitter.com/litmuschaos
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: litmuschaos
               accepted: '2020-06-25'
               incubating: '2022-01-11'
               dev_stats_url: https://litmuschaos.devstats.cncf.io/
@@ -10291,6 +10505,7 @@ landscape:
             project: sandbox
             crunchbase: https://www.crunchbase.com/organization/red-hat
             extra:
+              lfx_slug: krkn
               dev_stats_url: https://krknchaos.devstats.cncf.io
               slack_url: https://kubernetes.slack.com/messages/C05SFMHRWK1
               accepted: '2023-12-19'
@@ -10398,6 +10613,7 @@ landscape:
             logo: opencost.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: opencost
               accepted: '2022-06-17'
               incubating: '2024-10-25'
               slack_url: https://slack.cncf.io/
@@ -10634,6 +10850,7 @@ landscape:
             twitter: https://twitter.com/cortexmetrics
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: cortex
               accepted: '2018-09-20'
               incubating: '2020-08-20'
               dev_stats_url: https://cortex.devstats.cncf.io/
@@ -10779,6 +10996,7 @@ landscape:
             twitter: https://twitter.com/fluentd
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: fluentd
               accepted: '2016-11-08'
               incubating: '2016-11-08'
               graduated: '2019-04-11'
@@ -10805,6 +11023,7 @@ landscape:
             logo: fonio.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: ingraind
               accepted: '2021-03-30'
               archived: '2024-01-31'
           - item:
@@ -10893,6 +11112,7 @@ landscape:
             bluesky_url: https://bsky.app/profile/headlamp.dev
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: headlamp
               accepted: '2023-05-17'
               blog_url: https://headlamp.dev/blog
               slack_url: https://kubernetes.slack.com/messages/headlamp
@@ -10954,6 +11174,7 @@ landscape:
             logo: inspektor-gadget.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: inspektorgadget
               accepted: '2023-03-07'
               clomonitor_name: inspektor-gadget
               dev_stats_url: https://inspektorgadget.devstats.cncf.io/
@@ -10976,6 +11197,7 @@ landscape:
             twitter: https://twitter.com/JaegerTracing
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: jaeger
               accepted: '2017-09-13'
               incubating: '2017-09-13'
               graduated: '2019-10-31'
@@ -11007,6 +11229,7 @@ landscape:
             logo: k8sgpt.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: k8sgpt
               accepted: '2023-12-19'
               clomonitor_name: k8sgpt
               ai: true
@@ -11025,6 +11248,7 @@ landscape:
             logo: kepler.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kepler
               accepted: '2023-05-17'
               dev_stats_url: https://kepler.devstats.cncf.io/
               summary_personas: Developers, SREs, Sustainability Officers, IT Managers
@@ -11069,6 +11293,7 @@ landscape:
             logo: kuberhealthy.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: kuberhealthy
               accepted: '2021-03-30'
               annual_review_url: https://github.com/cncf/toc/pull/848
               annual_review_date: '2022-06-09'
@@ -11122,6 +11347,7 @@ landscape:
             twitter: https://twitter.com/kubelogging
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: logging-operator
               accepted: '2023-09-19'
               dev_stats_url: https://loggingoperator.devstats.cncf.io/
               artwork_url: https://github.com/cncf/artwork/blob/main/examples/sandbox.md/#logging-operator-logos
@@ -11308,6 +11534,7 @@ landscape:
             twitter: https://twitter.com/OpenMetricsIO
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: openmetrics
               accepted: '2018-08-10'
               incubating: '2022-02-03'
               archived: '2024-07-02'
@@ -11352,6 +11579,7 @@ landscape:
             twitter: https://twitter.com/opentelemetry
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: opentelemetry
               accepted: '2019-05-07'
               incubating: '2021-08-26'
               dev_stats_url: https://opentelemetry.devstats.cncf.io/
@@ -11380,6 +11608,7 @@ landscape:
             twitter: https://twitter.com/opentracing
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: opentracing
               accepted: '2016-10-11'
               incubating: '2016-10-11'
               archived: '2021-08-20'
@@ -11421,6 +11650,7 @@ landscape:
             branch: main
             twitter: https://x.com/PersesDev
             extra:
+              lfx_slug: perses
               accepted: '2024-08-29'
               dev_stats_url: https://perses.devstats.cncf.io/
               docker_url: https://hub.docker.com/r/persesdev/perses
@@ -11445,6 +11675,7 @@ landscape:
             twitter: https://twitter.com/pixie_run
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: pixie
               accepted: '2021-06-22'
               annual_review_url: https://github.com/cncf/toc/pull/908
               annual_review_date: '2022-09-20'
@@ -11471,6 +11702,7 @@ landscape:
             twitter: https://twitter.com/PrometheusIO
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: prometheus_del
               accepted: '2016-05-09'
               incubating: '2016-05-09'
               graduated: '2018-08-09'
@@ -11585,6 +11817,7 @@ landscape:
             logo: skooner.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: k8dash
               accepted: '2021-01-26'
               archived: '2024-10-24'
               annual_review_url: https://github.com/cncf/toc/pull/850
@@ -11651,6 +11884,7 @@ landscape:
             twitter: https://twitter.com/ThanosMetrics
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: thanos
               accepted: '2019-07-14'
               incubating: '2020-08-19'
               dev_stats_url: https://thanos.devstats.cncf.io/
@@ -11688,6 +11922,7 @@ landscape:
             logo: trickster.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: trickster
               accepted: '2021-03-30'
               annual_review_url: https://github.com/cncf/toc/pull/852
               annual_review_date: '2022-06-12'
@@ -18883,6 +19118,7 @@ landscape:
             logo: spin.svg
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
+              lfx_slug: spin
               accepted: '2025-01-21'
               dev_stats_url: https://spin.devstats.cncf.io/
           - item:
@@ -19176,6 +19412,7 @@ landscape:
             repo_url: https://github.com/container2wasm/container2wasm
             project: sandbox
             extra:
+              lfx_slug: container2wasm
               accepted: '2025-01-21'
           - item:
             name: containerd (Wasm)
@@ -19494,6 +19731,7 @@ landscape:
           repo_url: https://github.com/kaito-project/kaito
           logo: kaito.svg
           extra:
+            lfx_slug: kaito
             accepted: '2024-10-17'
             dev_stats_url: https://kaito.devstats.cncf.io/
         - item:
@@ -19505,6 +19743,7 @@ landscape:
           homepage_url: https://kserve.github.io/website/
           project: incubating
           extra:
+            lfx_slug: kserve
             accepted: '2025-09-29'
             incubating: '2025-09-29'
             blog_url: https://kserve.github.io/website/blog
@@ -19713,6 +19952,8 @@ landscape:
           logo: ./prometheus-icon-color.svg
           unnamed_organization: true
           homepage_url: https://prometheus.io/
+          extra:
+              lfx_slug: prometheus_del
         - item:
           name: Influxdb
           description: InfluxDB is an open source time series database written in Rust, using Apache Arrow, Apache Parquet, and Apache DataFusion as its foundational building blocks.


### PR DESCRIPTION
### Changes
This PR adds the `lfx_slug` field inside the extra section of all projects that exist in LFX.
This change follows the support of the `lfx_slug` field added in this [PR](https://github.com/cncf/landscape2/pull/893/files).

For future projects, this PR also adds instructions on how the `lfx_slug` could be obtained and added to the yml file.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
