### PR TITLE
Add Keycloak to CNAI Landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1515,6 +1515,8 @@ landscape:
             logo: keycloak.svg
             twitter: https://twitter.com/keycloak
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            second_path:
+              - "CNAI / Governance, Policy & Security"
             extra:
               lfx_slug: keycloak
               accepted: '2023-04-10'


### PR DESCRIPTION
I propose adding Keycloak to the CNAI landscape because it supports OAuth 2.1 as required by the MCP authorization specification.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
