### PR TITLE
Update kaniko repository URL to Chainguard repo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7379,8 +7379,8 @@ landscape:
             twitter: https://twitter.com/jreleaser
           - item:
             name: kaniko
-            homepage_url: https://github.com/GoogleContainerTools/kaniko
-            repo_url: https://github.com/GoogleContainerTools/kaniko
+            homepage_url: https://github.com/chainguard-dev/kaniko
+            repo_url: https://github.com/chainguard-dev/kaniko
             logo: kaniko.svg
             twitter: https://twitter.com/GCPcloud
             crunchbase: https://www.crunchbase.com/organization/google


### PR DESCRIPTION
The original Google Container Tools kaniko repository has been archived.
Updated both homepage_url and repo_url to point to the actively maintained Chainguard repository at https://github.com/chainguard-dev/kaniko.

Fixes #4574