### PR TITLE
Add Higress to CNAI Landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -5460,6 +5460,8 @@ landscape:
             repo_url: https://github.com/alibaba/higress
             logo: higress.svg
             crunchbase: https://www.crunchbase.com/organization/alibaba-cloud
+            second_path:
+              - "CNAI / Governance, Policy & Security"
           - item:
             name: Kgateway
             description: An Envoy-powered, Kubernetes-native API Gateway that integrates Kubernetes Gateway API with a control plane for API connectivity in any cloud environment. 


### PR DESCRIPTION
I propose adding Higress to the CNAI landscape because it's AI gateway capabilities support all [mainstream model providers](https://github.com/alibaba/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider) both domestic and international. It also supports hosting MCP (Model Context Protocol) Servers through its plugin mechanism, enabling AI Agents to easily call various tools and services. 


### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
