### PR TITLE
docs: add explanations for Serverless, Members, and Special layers in…

### DIFF
--- a/docs/landscape-guide.md
+++ b/docs/landscape-guide.md
@@ -1,0 +1,23 @@
+# Landscape Guide — Architecture Layers
+
+The architecture diagram includes multiple columns and a bottom-most layer labeled **Special**, which are not currently documented.  
+This document provides clear explanations for those components.
+
+---
+
+### Serverless Column
+Represents services that run without dedicated server management, scale automatically, and execute on demand or via events.  
+Common use: cloud functions, scheduled triggers, background event-driven tasks.  
+Examples: AWS Lambda, Azure Functions, Google Cloud Functions.
+
+---
+
+### Members Column
+Represents users or entities that interact with, own, or maintain parts of the landscape.  
+Includes maintainers, contributors, project owners, or affiliated members with access or responsibility in the system.
+
+---
+
+### Special Layer (Bottom-most)
+Contains components that do not belong to standard infrastructure categories but are still essential to the ecosystem.  
+Includes internal tools, experimental modules, auxiliary automation, legacy support services, or one-off dependencies that require separate classification.


### PR DESCRIPTION
## Issue
The current Landscape Guide diagram includes a "Serverless" column, a "Members" column, and a bottom-most layer labeled "Special", but there is no accompanying explanation in the documentation.

Since these elements are part of the official diagram, adding descriptions for them would improve clarity, completeness, and usability — especially for new contributors trying to understand the architecture.

## Proposed Changes
- Add a short explanation for the **Serverless** column (purpose and examples)
- Add a short explanation for the **Members** column (who it represents and role)
- Add a section describing the **Special** layer (why it exists, what it includes, and how it differs from other layers)

## Benefits
- Makes documentation more complete
- Helps contributors better understand architecture
- Improves onboarding for beginners
- Avoids confusion and assumptions about undocumented sections

Let me know if you'd like me to format the content in a specific style to match the repo.
