### PR TITLE
Add k0rdent to Certified Kubernetes - Distribution

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -4308,6 +4308,8 @@ landscape:
             twitter: https://x.com/k0rdent
             crunchbase: https://www.crunchbase.com/organization/mirantis
             allow_duplicate_repo: true
+            second_path:
+              - "Platform / Certified Kubernetes - Distribution"
             extra:
               chat_channel: '#k0rdent'
               slack_url: http://slack.cncf.io/


### PR DESCRIPTION
k0rdent has been certified as Kubernetes conformant (v1.35) via https://github.com/cncf/k8s-conformance/pull/4167. Adding second_path to list it under Certified Kubernetes - Distribution.