### PR TITLE
Move NoKV to Cloud Native Storage

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2981,6 +2981,14 @@ landscape:
             logo: netapp.svg
             crunchbase: https://www.crunchbase.com/organization/netapp
           - item:
+            name: NoKV
+            description: NoKV is a native metadata service for distributed filesystems, object storage namespaces, and AI dataset workloads.
+            homepage_url: https://github.com/feichai0017/NoKV
+            repo_url: https://github.com/feichai0017/NoKV
+            logo: nokv.svg
+            second_path:
+              - "AI Native Infra / Storage"
+          - item:
             name: Nutanix Data Services for Kubernetes (NDK)
             description: Protect containerized applications with enterprise grade data services to meet compliance and regulatory requirements.
             homepage_url: https://www.nutanix.com/products/data-services-for-kubernetes
@@ -6183,13 +6191,6 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/neo-technology
             second_path:
               - "AI Agent / Knowledge Graph"
-          - item:
-            name: NoKV
-            description: >-
-              NoKV is a full-stack distributed key-value storage platform written from scratch in Go, including its own LSM engine, Raft implementation, control plane, and MVCC layer.
-            homepage_url: https://github.com/feichai0017/NoKV
-            repo_url: https://github.com/feichai0017/NoKV
-            logo: nokv.svg
           - item:
             name: NuoDB
             homepage_url: https://www.nuodb.com/


### PR DESCRIPTION
## Summary

- Move NoKV from Database to Runtime / Cloud Native Storage.
- Update the description to its current positioning as a native metadata service for distributed filesystems, object storage namespaces, and AI dataset workloads.
- Add AI Native Infra / Storage as a secondary path.
