### PR TITLE
Update mirrord description and homepage_url

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7678,8 +7678,8 @@ landscape:
           - item:
             name: mirrord
             description: >-
-              mirrord is an open-source tool that lets developers run local processes in the context of their cloud environment. It provides the benefits of running your service on a cloud environment (e.g. staging) without actually going through the hassle of deploying it there, and without disrupting the environment by deploying untested code.
-            homepage_url: https://www.mirrord.dev/
+              mirrord is an open-source developer tool that runs local code as if it were a pod in a remote Kubernetes cluster, with real env vars, DNS, network, and inbound traffic. Lets engineers iterate on a single service locally while interacting with the rest of the cluster, and is also used by AI coding agents (Claude, Cursor, Codex).
+            homepage_url: https://metalbear.com/mirrord/
             repo_url: https://github.com/metalbear-co/mirrord
             logo: mirrord.svg
             crunchbase: https://www.crunchbase.com/organization/metalbear


### PR DESCRIPTION
Updates the existing mirrord entry in App Definition and Development → Application Definition & Image Build (alongside Telepresence, Skaffold, Tilt, Okteto, Gefyra).

## Changes

**1. Description refresh.** The previous text was generic ("cloud environment") and predates mirrord's Kubernetes-specific positioning. New description names the actual mechanism (env vars, DNS, network, inbound traffic) and notes the AI-agent audience that grew over the last 12 months.

**2. `homepage_url`** changed from `https://www.mirrord.dev/` to `https://metalbear.com/mirrord/`. mirrord.dev is a 301 redirect to the same canonical page; this avoids the redirect hop.

## Pre-submission checklist

This is an entry update, not a new entry, so most checklist items are pre-existing and unchanged. The relevant ones:

- [x] Project is open source with 5,059 GitHub stars (well over 300 threshold)
- [x] Single best category — already placed alongside peer tools (Telepresence, Skaffold, Tilt, Okteto, Gefyra)
- [x] Logo, repo_url, crunchbase fields unchanged

DCO sign-off included on the commit.