### PR TITLE
Remove 'servicememe' entries from landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -13189,13 +13189,6 @@ landscape:
             logo: sap.svg
             crunchbase: https://www.crunchbase.com/organization/sap
           - item:
-            name: servicememe (KCSP)
-            description: >-
-              We are committed to providing customers with high-quality IT services. We specialize in cloud native managed services and transformation from legacy to cloud native environments，help enterprises secure their cloud native applications from development to production, and provide enterprise-level Cloud Native, CICD and DevOps products, solutions and best practices.
-            homepage_url: https://www.servicememe.com/services/training/
-            logo: servicememe.svg
-            crunchbase: https://www.crunchbase.com/organization/servicememe
-          - item:
             name: Shandong Cvicse Middleware (KCSP)
             description: >-
               Shandong Cvicse Middleware provides specialized Kubernetes technical services, encompassing consultation, training, implementation, and technical support, as well as advanced services such as customized development and business operations maintenance. Our objective is to empower enterprises to swiftly adopt Kubernetes, better meeting the demands of business growth and accelerating the prosperous expansion of their operations.
@@ -13782,15 +13775,6 @@ landscape:
             extra:
               training_certifications: cka, ckad, cks, kcna
               training_type: instructor-led
-          - item:
-            name: servicememe (KCNTP)
-            description: servicememe provides Kubernetes training services in the Japan market.
-            homepage_url: https://www.servicememe.com/services/training/
-            logo: servicememe.svg
-            crunchbase: https://www.crunchbase.com/organization/servicememe
-            extra:
-              training_certifications: cka, ckad, cks
-              training_type: e-learning, instructor-led
           - item:
             name: Shinesoft (KCNTP)
             description: We provide design, development and tech support include; Cloud/Cluster, Network, Server, Security, Monitoring, Data analysis, and AI/IoT
@@ -16099,12 +16083,6 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/daimler
             joined: '2020-08-01'
           - item:
-            name: Merly (member)
-            homepage_url: https://www.merly.ai/
-            logo: merly.svg
-            crunchbase: https://www.crunchbase.com/organization/merly
-            joined: '2023-04-01'
-          - item:
             name: meshcloud (member)
             homepage_url: https://www.meshcloud.io
             logo: meshcloud.svg
@@ -16385,12 +16363,6 @@ landscape:
             logo: ollygarden.svg
             crunchbase: https://www.crunchbase.com/organization/ollygarden
             joined: '2025-12-01'
-          - item:
-            name: oodle.ai (member)
-            homepage_url: https://oodle.ai
-            logo: oodle.svg
-            crunchbase: https://www.crunchbase.com/organization/oodle-ai
-            joined: '2024-09-01'
           - item:
             name: OPENMARU (member)
             homepage_url: https://www.openmaru.io
@@ -16896,12 +16868,6 @@ landscape:
             logo: seowon-information.svg
             crunchbase: https://www.crunchbase.com/organization/seowon-information-co-ltd
             joined: '2024-11-01'
-          - item:
-            name: servicememe (member)
-            homepage_url: https://www.servicememe.com/
-            logo: servicememe.svg
-            crunchbase: https://www.crunchbase.com/organization/servicememe
-            joined: '2019-10-01'
           - item:
             name: Shandong Cvicse Middleware (member)
             homepage_url: https://www.inforbus.com/


### PR DESCRIPTION
Removed multiple entries for 'servicememe' from the landscape.yml file, including its descriptions, homepage URLs, logos, and Crunchbase links.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
