### PR TITLE
Add AI Platform second_path for Viettel in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -9095,6 +9095,8 @@ landscape:
             homepage_url: https://viettelcloud.vn/
             logo: viettel.svg
             crunchbase: https://www.crunchbase.com/organization/viettel
+            second_path:
+              - "Platform / Certified Kubernetes - AI Platform"
           - item:
             name: Viettel Cloud Kubernetes Platform
             description: Viettel Cloud Kubernetes platform provides container management and orchestration for the applications that based on Cloud Native Architecture and run in a container environment.


### PR DESCRIPTION
Add Viettel AI Platform into Certified Kubernetes - AI Platform.
Our AI Conformance PR has been merged: https://github.com/cncf/k8s-ai-conformance/pull/85