### PR TITLE
ci(validate): pin contents: read

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   validate-landscape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to the landscape validation workflow. `cncf/landscape2-validate-action@v2` only inspects the checked-out `landscape.yml`; no API writes.

YAML validated locally.