### PR TITLE
Add Kruize to Continuous Optimization

### DIFF
--- a/hosted_logos/kruize.svg
+++ b/hosted_logos/kruize.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1024 1310">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: url(#radial-gradient-2);
+      }
+
+      .cls-1, .cls-2, .cls-3, .cls-4 {
+        mix-blend-mode: multiply;
+      }
+
+      .cls-5 {
+        fill: #004e98;
+      }
+
+      .cls-6 {
+        fill: #ff9d00;
+      }
+
+      .cls-7 {
+        fill: #9db7d2;
+      }
+
+      .cls-2 {
+        fill: url(#linear-gradient-2);
+      }
+
+      .cls-3 {
+        fill: url(#radial-gradient);
+      }
+
+      .cls-4 {
+        fill: url(#linear-gradient);
+      }
+
+      .cls-8 {
+        isolation: isolate;
+      }
+    </style>
+    <radialGradient id="radial-gradient" cx="506.94" cy="218.08" fx="506.94" fy="218.08" r="733.21" gradientUnits="userSpaceOnUse">
+      <stop offset=".23" stop-color="#fff"/>
+      <stop offset=".8" stop-color="#ff9d00"/>
+    </radialGradient>
+    <radialGradient id="radial-gradient-2" cx="509.9" cy="205.27" fx="509.9" fy="205.27" r="771.62" gradientUnits="userSpaceOnUse">
+      <stop offset=".56" stop-color="#fff"/>
+      <stop offset="1" stop-color="#004e98"/>
+    </radialGradient>
+    <linearGradient id="linear-gradient" x1="334.36" y1="244.63" x2="-156.09" y2="892.19" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#3a6ea5"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="-4057.67" y1="244.63" x2="-4548.12" y2="892.19" gradientTransform="translate(-3368.03) rotate(-180) scale(1 -1)" xlink:href="#linear-gradient"/>
+  </defs>
+  <g class="cls-8">
+    <g id="Layer_1" data-name="Layer 1">
+      <g>
+        <path class="cls-5" d="m90.7,1223.4l-19.38,20.69v45.82H20v-183.29h51.32v76.2l70.96-76.2h57.08l-74.89,81.17,78.82,102.12h-60.22l-52.37-66.51Z"/>
+        <path class="cls-5" d="m291.79,1241.21h-28.28v48.7h-51.84v-183.29h83.79c50.01,0,81.43,25.92,81.43,67.82,0,26.97-13.09,46.87-35.87,57.87l39.54,57.61h-55.51l-33.25-48.7Zm.52-93.74h-28.8v53.68h28.8c21.47,0,32.21-9.95,32.21-26.71s-10.74-26.97-32.21-26.97Z"/>
+        <path class="cls-5" d="m398.62,1208.22v-101.6h51.85v100.03c0,31.42,13.09,43.99,34.82,43.99s34.56-12.57,34.56-43.99v-100.03h51.06v101.6c0,54.73-31.94,85.36-86.15,85.36s-86.15-30.64-86.15-85.36Z"/>
+        <path class="cls-5" d="m600.77,1106.62h51.84v183.29h-51.84v-183.29Z"/>
+        <path class="cls-5" d="m839.3,1248.8v41.11h-164.18v-32.47l92.43-109.71h-90.08v-41.11h157.89v32.47l-92.43,109.71h96.36Z"/>
+        <path class="cls-5" d="m1004,1249.85v40.06h-147.16v-183.29h143.75v40.06h-92.43v30.9h81.43v38.75h-81.43v33.52h95.84Z"/>
+      </g>
+      <g>
+        <rect class="cls-6" x="20.54" y="20" width="982.93" height="171.86"/>
+        <rect class="cls-3" x="20.54" y="20" width="982.93" height="171.86"/>
+        <polygon class="cls-5" points="564.46 270.11 880.73 1002.92 143.27 1002.92 459.54 270.11 564.46 270.11"/>
+        <polygon class="cls-1" points="564.46 270.11 880.73 1002.92 143.27 1002.92 459.54 270.11 564.46 270.11"/>
+        <g>
+          <polygon class="cls-7" points="20.54 270.11 370.85 270.11 54.57 1002.92 20.54 1002.92 20.54 270.11"/>
+          <polygon class="cls-4" points="20.54 270.11 370.85 270.11 54.57 1002.92 20.54 1002.92 20.54 270.11"/>
+        </g>
+        <g>
+          <polygon class="cls-7" points="1003.46 270.11 653.15 270.11 969.43 1002.92 1003.46 1002.92 1003.46 270.11"/>
+          <polygon class="cls-2" points="1003.46 270.11 653.15 270.11 969.43 1002.92 1003.46 1002.92 1003.46 270.11"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -10587,6 +10587,13 @@ landscape:
             logo: infracost.svg
             crunchbase: https://www.crunchbase.com/organization/infracost
           - item:
+            name: Kruize
+            description: Kruize analyzes your Kubernetes workload metrics and automatically generates right-sizing recommendations for CPU, memory, and GPU resources — reducing costs and improving performance without manual tuning.
+            homepage_url: https://kruize.github.io/kruize-website/
+            repo_url: https://github.com/kruize/autotune
+            crunchbase: https://www.crunchbase.com/organization/ibm
+            logo: kruize.svg
+          - item:
             name: Kubecost
             homepage_url: https://www.kubecost.com/
             repo_url: https://github.com/kubecost/cost-model


### PR DESCRIPTION
Adds Kruize to Continuous Optimization.

Kruize analyzes your Kubernetes workload metrics and automatically generates right-sizing recommendations for CPU, memory, and GPU resources — reducing costs and improving performance without manual tuning.

Homepage: https://kruize.github.io/kruize-website/
Repo:  https://github.com/kruize/autotune
Crunchbase: https://www.crunchbase.com/organization/ibm

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
