### PR TITLE
Update OpenTelemetry entry

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -11662,7 +11662,6 @@ landscape:
             project: graduated
             repo_url: https://github.com/open-telemetry/community
             logo: open-telemetry.svg
-            twitter: https://twitter.com/opentelemetry
             crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             second_path:
               - "AI Native Infra / Observability"
@@ -11672,9 +11671,12 @@ landscape:
               incubating: '2021-08-26'
               graduated: '2026-05-11'
               dev_stats_url: https://opentelemetry.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/incubating.md#opentelemetry-logos
+              documentation_url: https://opentelemetry.io/docs/
+              artwork_url: https://github.com/cncf/artwork/blob/main/examples/graduated.md#opentelemetry-logos
               slack_url: https://cloud-native.slack.com/messages/opentelemetry
-              gitter_url: https://gitter.im/open-telemetry/community
+              blog_url: https://blog.opentelemetry.io/
+              youtube_url: https://www.youtube.com/@otel-official
+              stack_overflow_url: https://stackoverflow.com/questions/tagged/open-telemetry
               specification: true
               chat_channel: '#opentelemetry'
               summary_personas: Developers, SREs, Platform Engineers, DevOps
@@ -11686,6 +11688,13 @@ landscape:
               summary_integrations: Prometheus, Jaeger, [and many more.](https://opentelemetry.io/ecosystem/)
               summary_intro_url: https://opentelemetry.io/ecosystem/demo/
               clomonitor_name: open-telemetry
+              other_links:
+                - name: Bluesky
+                  url: https://bsky.app/profile/opentelemetry.io
+                - name: Mastodon
+                  url: https://fosstodon.org/@opentelemetry
+                - name: LinkedIn
+                  url: https://www.linkedin.com/company/opentelemetry/
           - item:
             name: OpenTracing
             homepage_url: https://opentracing.io/


### PR DESCRIPTION
Updates OpenTelemetry entry:

- Removes Twitter link since the account is no longer in use
- Removes Gitter URL since Gitter is no longer used
- Updates Artwork URL after cncf/artwork/pull/654
- Adds blog URL
- Adds Youtube URL
- Adds StackOverflow URL
- Adds other links (Bluesky, Mastodon, LinkedIn)

Relates to cncf/cncf.io/issues/956.

ccing all OTel Governance Committee members: @austinlparker @tedsuo @jpkrohling @trask @maryliag @mtwo @alolita @svrnm

