### PR TITLE
ci(validate): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   validate-landscape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `validate` workflow runs landscape validation only. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.