### PR TITLE
Add AI Platform second_path for vCluster in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -9106,6 +9106,8 @@ landscape:
             repo_url: https://github.com/loft-sh/vcluster
             logo: vcluster.svg
             crunchbase: https://www.crunchbase.com/organization/vcluster
+            second_path:
+              - "Platform / Certified Kubernetes - AI Platform"
           - item:
             name: Viettel AI Platform
             description: Viettel AI Platform is a container management and orchestration platform based on Cloud Native architecture, designed to support AI/ML applications running in Kubernetes environments.


### PR DESCRIPTION
Add vCluster into Certified Kubernetes - AI Platform.

Our AI Conformance PRs have been merged:
- Kubernetes 1.35: https://github.com/cncf/k8s-ai-conformance/pull/83
- Kubernetes 1.34: https://github.com/cncf/k8s-ai-conformance/pull/82

cc @taylorwaggoner