### PR TITLE
Add Attune - in-place pod resource right-sizing operator

### DIFF
--- a/hosted_logos/attune.svg
+++ b/hosted_logos/attune.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <!-- Rounded-rectangle background -->
+  <rect x="0" y="0" width="1024" height="1024" rx="180" ry="180" fill="#2C51A1"/>
+
+  <!-- Gauge arc: center at (512,640), outer R=340, inner r=200 -->
+  <g>
+    <!-- Red segment: 195° to 237° -->
+    <path d="M 183.6,552.0 A 340,340 0 0,1 326.8,354.9 L 403.1,472.3 A 200,200 0 0,0 318.8,588.2 Z" fill="#E44F39"/>
+
+    <!-- Yellow segment: 237° to 312° -->
+    <path d="M 326.8,354.9 A 340,340 0 0,1 739.5,387.3 L 645.8,491.4 A 200,200 0 0,0 403.1,472.3 Z" fill="#FBC917"/>
+
+    <!-- Green segment: 312° to 345° -->
+    <path d="M 739.5,387.3 A 340,340 0 0,1 840.4,552.0 L 705.2,588.2 A 200,200 0 0,0 645.8,491.4 Z" fill="#44AC4D"/>
+
+    <!-- White teardrop needle pointing into green zone -->
+    <polygon points="700,505 550,637 526,605" fill="white"/>
+
+    <!-- Center pivot circle -->
+    <circle cx="512" cy="640" r="32" fill="white"/>
+  </g>
+</svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -10546,6 +10546,13 @@ landscape:
             logo: akamas.svg
             crunchbase: https://www.crunchbase.com/organization/akamas
           - item:
+            name: Attune
+            description: Kubernetes operator for safe, in-place pod resource right-sizing using real Prometheus metrics. Modern VPA replacement.
+            homepage_url: https://github.com/attune-io/attune
+            repo_url: https://github.com/attune-io/attune
+            logo: attune.svg
+            unnamed_organization: true
+          - item:
             name: BMC Helix
             homepage_url: https://www.bmc.com/it-solutions/bmc-helix.html
             logo: bmc.svg


### PR DESCRIPTION
## Add Attune to Continuous Optimization

[Attune](https://github.com/attune-io/attune) is a Kubernetes operator for safe, in-place pod resource right-sizing using real Prometheus metrics. It is a modern replacement for VPA (Vertical Pod Autoscaler), leveraging the Kubernetes 1.32+ In-Place Pod Resize feature to adjust CPU and memory without restarts.

**Category:** Observability and Analysis → Continuous Optimization

### Requirements checklist

- **Open source:** Yes — Apache License 2.0
- **Repo:** https://github.com/attune-io/attune
- **Active development:** Yes — regular commits, issues, and releases
- **Released:** Yes — tagged releases available, Helm chart published on GHCR, Docker Hub, and Artifact Hub
- **Cloud native:** Kubernetes-native operator built with controller-runtime, Kubebuilder, and Go
- **SVG logo:** Included in `hosted_logos/attune.svg`