### PR TITLE
Add kube-llmops to Inference/Framework category

### DIFF
--- a/kube-llmops.svg
+++ b/kube-llmops.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f172a"/>
+      <stop offset="100%" style="stop-color:#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="60" rx="8" fill="url(#bg)"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="11" fill="#e2e8f0">
+    <tspan x="50%" dy="-6" font-weight="bold" fill="#10b981">kube</tspan><tspan font-weight="bold" fill="#e2e8f0">-llmops</tspan>
+    <tspan x="50%" dy="14" font-size="8" fill="#64748b">K8s-Native LLMOps</tspan>
+  </text>
+</svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -19575,6 +19575,13 @@ landscape:
               dev_stats_url: https://kserve.devstats.cncf.io/
               ai: true
           - item:
+            name: kube-llmops
+            description: Kubernetes-native LLMOps Platform. One Helm chart to deploy complete LLM infrastructure on Kubernetes: model serving (vLLM, llama.cpp), AI Gateway (LiteLLM), observability (Grafana, Langfuse), RAG, fine-tuning, SSO, autoscaling.
+            repo_url: https://github.com/GaeaRuiW/kube-llmops
+            logo: ./kube-llmops.svg
+            unnamed_organization: true
+            homepage_url: https://gaearuiw.github.io/kube-llmops/
+          - item:
             name: llm-d
             description: a Kubernetes-native high-performance distributed LLM inference framework.
             repo_url: https://github.com/llm-d/llm-d


### PR DESCRIPTION
Add [kube-llmops](https://github.com/GaeaRuiW/kube-llmops) to the CNCF Landscape under **Inference > Framework**.

kube-llmops is a Kubernetes-native LLMOps Platform that deploys complete LLM infrastructure with one Helm chart: model serving (vLLM, llama.cpp), AI Gateway (LiteLLM), observability (Grafana, Langfuse tracing), RAG with Dify, fine-tuning with LLaMA-Factory, Keycloak SSO, and KEDA autoscaling.