### PR TITLE
Update Zig info

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -18511,9 +18511,9 @@ landscape:
             name: Zig
             description: Compiled language to Wasm
             homepage_url: https://ziglang.org/
-            repo_url: https://github.com/ziglang/zig
+            repo_url: https://codeberg.org/ziglang/zig
             logo: zig.svg
-            crunchbase: https://www.crunchbase.com/organization/google
+            unnamed_organization: true
       - subcategory:
         name: Runtimes
         items:


### PR DESCRIPTION
The landscape wrongfully shows Zig as pertaining to Google.

The Zig Programming Language is governed by the Zig Software Foundation, which does not have a crunchbase page.

Also, Zig has moved its repo to Codeberg. The GitHub repo is not mirrored.