### PR TITLE
Mark Velero as a CNCF Sandbox project (accepted 2026-03-11)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3206,12 +3206,16 @@ landscape:
           - item:
             name: Velero
             homepage_url: https://velero.io
-            repo_url: https://github.com/vmware-tanzu/velero
+            project: sandbox
+            repo_url: https://github.com/velero-io/velero
             logo: project-velero.svg
             twitter: https://twitter.com/projectvelero
-            crunchbase: https://www.crunchbase.com/organization/vmware
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             extra:
               lfx_slug: velero
+              accepted: '2026-03-11'
+              dev_stats_url: https://velero.devstats.cncf.io/
+              clomonitor_name: velero
           - item:
             name: Vineyard
             description: Vineyard (v6d) is an in-memory immutable data manager.


### PR DESCRIPTION
## Summary

This PR updates the Velero entry in the CNCF Landscape to reflect its formal acceptance as a CNCF Sandbox project on March 11, 2026.

## Changes

- Added `project: sandbox`
- Updated `repo_url` to the new canonical GitHub org: `https://github.com/velero-io/velero`
- Updated `crunchbase` to point to the CNCF organization
- Added `extra.accepted: '2026-03-11'`
- Added `extra.dev_stats_url: https://velero.devstats.cncf.io/`
- Added `extra.clomonitor_name: velero`

## References

Sandbox onboarding tracking issue: cncf/sandbox#473