### PR TITLE
Add STCLAB to Kubernetes service providers list

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -13372,6 +13372,13 @@ landscape:
             logo: stackgenie.svg
             crunchbase: https://www.crunchbase.com/organization/stackgenie
           - item:
+            name: STCLAB (KCSP)
+            description: >-
+              Backed by 3+ years of operating high-traffic B2B services on Amazon EKS, we provide Kubernetes professional services — consulting, implementation, 24x7 support, and customer enablement training — that help enterprises reduce downtime, control infrastructure costs, and scale customer experience in production.
+            homepage_url: https://platform.stclab.com/kubernetes
+            logo: stclab.svg
+            crunchbase: https://www.crunchbase.com/organization/stc-lab            
+          - item:
             name: Steamhaus (KCSP)
             description: >-
               Steamhaus are AWS cloud native experts, specialising in designing, building and operating containers and serverless platforms. We help startups scale fast and securely, and we help enterprises accelerate and derisk modernisation and transformation.


### PR DESCRIPTION
Added STCLAB as a Kubernetes professional service provider with details.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
