### PR TITLE
Fix OpenYurt description and artwork URL

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -592,7 +592,7 @@ landscape:
               clomonitor_name: opentofu
           - item:
             name: OpenYurt
-            description: An open platform that extending your native Kubernetes to edge.
+            description: An open platform that extends upstream Kubernetes to Edge.
             homepage_url: https://openyurt.io/
             project: incubating
             repo_url: https://github.com/openyurtio/openyurt
@@ -609,7 +609,7 @@ landscape:
               annual_review_date: '2023-06-02'
               dev_stats_url: https://openyurt.devstats.cncf.io/
               clomonitor_name: openyurt
-              artwork_url: https://github.com/cncf/artwork/tree/master/projects/openyurt
+              artwork_url: https://github.com/cncf/artwork/tree/main/projects/openyurt
           - item:
             name: Project Syn
             homepage_url: https://syn.tools/


### PR DESCRIPTION
Hi,
I stumbled upon a grammatical error on the OpenYurt project page: https://www.cncf.io/projects/openyurt/
So, I've updated the description to match the official tagline from the website: https://openyurt.io/

Also, on https://github.com/cncf/artwork, the branch master has been renamed to main, so I've updated this project's artwork URL to be consistent as well. Though, this might be something to do at a bigger scale on all current projects.