### PR TITLE
Mark Apicurio Registry as CNCF sandbox project

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6676,11 +6676,15 @@ landscape:
             name: Apicurio Registry
             description: 'Apicurio Registry is a runtime server system that stores a specific set of artifacts as files. '
             homepage_url: https://www.apicur.io
+            project: sandbox
             repo_url: https://github.com/Apicurio/apicurio-registry
             project_org: https://github.com/Apicurio
             logo: apicurio-registry.svg
             twitter: https://twitter.com/apicurio
-            crunchbase: https://www.crunchbase.com/organization/red-hat
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+            extra:
+              lfx_slug: apicurio-registry
+              accepted: '2026-03-12'
           - item:
             name: ArkFlow
             description: >-


### PR DESCRIPTION
Apicurio Registry was accepted as a CNCF sandbox project (vote closed 2026-03-12).

This PR:
- Adds `project: sandbox`
- Updates `crunchbase` to the CNCF organization
- Adds `extra` block with `lfx_slug: apicurio-registry` and `accepted: '2026-03-12'`

Refs: cncf/sandbox#495, cncf/sandbox#461