### PR TITLE
Add freelens-pod-filebrowser to App Definition and Development

### DIFF
--- a/hosted_logos/freelens-pod-filebrowser.svg
+++ b/hosted_logos/freelens-pod-filebrowser.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <defs>
+    <linearGradient id="folderGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#326CE5;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1a4db3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="innerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#E8F0FE;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#C5D9F5;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="25" width="80" height="60" rx="6" ry="6" fill="url(#folderGrad)"/>
+  <path d="M10 35 L10 25 Q10 19 16 19 L42 19 L48 25 L84 25 Q90 25 90 31 L90 35 Z" fill="#245AB3"/>
+  <rect x="25" y="42" width="50" height="4" rx="2" fill="url(#innerGrad)" opacity="0.9"/>
+  <rect x="25" y="52" width="38" height="4" rx="2" fill="url(#innerGrad)" opacity="0.7"/>
+  <rect x="25" y="62" width="44" height="4" rx="2" fill="url(#innerGrad)" opacity="0.5"/>
+  <rect x="25" y="72" width="30" height="4" rx="2" fill="url(#innerGrad)" opacity="0.3"/>
+</svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -7343,6 +7343,14 @@ landscape:
             twitter: https://twitter.com/fabric8io
             crunchbase: https://www.crunchbase.com/organization/red-hat
           - item:
+            name: freelens-pod-filebrowser
+            description: >-
+              Freelens extension for browsing, viewing, editing, uploading, and deleting files inside Kubernetes pod containers directly from the Freelens UI. Eliminates the need for repetitive kubectl exec commands during debugging.
+            homepage_url: https://github.com/masoudei/freelens-pod-filebrowser
+            repo_url: https://github.com/masoudei/freelens-pod-filebrowser
+            logo: freelens-pod-filebrowser.svg
+            open_source: true
+          - item:
             name: Gefyra
             description: >-
               Gefyra runs local code in any Kubernetes cluster without the build and push cycle. It overlays containers in the cluster making code changes immediately available.


### PR DESCRIPTION
## Summary

Add [freelens-pod-filebrowser](https://github.com/masoudei/freelens-pod-filebrowser) to the CNCF Landscape under **App Definition and Development** > **Application Definition & Image Build**.

## About

freelens-pod-filebrowser is a Freelens extension that lets you browse, view, edit, upload, and delete files inside Kubernetes pod containers directly from the Freelens UI. It eliminates the need for repetitive \kubectl exec\ commands during debugging.

## Checklist
- [x] I have read the contribution guidelines
- [x] The project is open source (MIT License)
- [x] Logo SVG is added to hosted_logos/
- [x] Entry is placed in the correct category/subcategory
- [x] Format follows existing entries