### PR TITLE
Add SourceFuse and update Decathlon role in landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -13386,6 +13386,13 @@ landscape:
             logo: source-allies.svg
             crunchbase: https://www.crunchbase.com/organization/source-allies-inc
           - item:
+            name: SourceFuse (KCSP)
+            description: >-
+              SourceFuse delivers end-to-end Kubernetes services - from architecture consulting to production-grade managed operations - for enterprises in healthcare, fintech, and SaaS.
+            homepage_url: https://www.sourcefuse.com/kcsp-partner
+            logo: sourcefuse.svg
+            crunchbase: https://www.crunchbase.com/organization/sourcefuse            
+          - item:
             name: SparkFabrik (KCSP)
             description: We provide cloud native custom development and services on top of Kubernetes, helping our customers to transition to the cloud native era.
             homepage_url: https://www.sparkfabrik.com/en/services/cloud-native-services/kubernetes-consultancy
@@ -18120,7 +18127,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/db-systel
             joined: '2020-04-01'
           - item:
-            name: Decathlon (supporter)
+            name: Decathlon (contributor)
             homepage_url: https://digital.decathlon.net/
             logo: decathlon.svg
             crunchbase: https://www.crunchbase.com/organization/decathlon-technology


### PR DESCRIPTION
Added SourceFuse as a KCSP partner with details and updated Decathlon's role from supporter to contributor.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
