### PR TITLE
fix: update HAMi homepage_url to project-hami.io

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -4246,7 +4246,7 @@ landscape:
           - item:
             name: HAMi
             description: Heterogeneous AI Computing Virtualization Middleware
-            homepage_url: https://project-hami.github.io/HAMi/
+            homepage_url: https://project-hami.io/
             project: incubating
             repo_url: https://github.com/Project-HAMi/HAMi
             logo: hami.svg


### PR DESCRIPTION
The current homepage_url for HAMi (https://project-hami.github.io/HAMi/) is a stale GitHub Pages mirror of the repo README. It is out of date and not actively maintained. https://project-hami.io/ is the project's real, actively maintained documentation site.

Related: https://github.com/cncf/cncf.io/issues/959