### PR TITLE
Add kiac

### DIFF
--- a/hosted_logos/kiac.svg
+++ b/hosted_logos/kiac.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 440" width="480" height="440" role="img" aria-labelledby="title desc">
+  <title id="title">kiac</title>
+  <desc id="desc">Kubernetes in Apple Containers</desc>
+  <defs>
+    <linearGradient id="kiac-hex" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4F8BF0"/>
+      <stop offset="1" stop-color="#2D5FD0"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(78 0) scale(1.35)">
+    <path d="M120 30 L198 75 L198 165 L120 210 L42 165 L42 75 Z"
+          fill="url(#kiac-hex)" stroke="url(#kiac-hex)" stroke-width="20" stroke-linejoin="round"/>
+    <g stroke="#FFFFFF" stroke-width="6" stroke-linecap="round" opacity="0.55">
+      <line x1="120" y1="88" x2="88" y2="150"/>
+      <line x1="120" y1="88" x2="152" y2="150"/>
+      <line x1="88" y1="150" x2="152" y2="150"/>
+    </g>
+    <circle cx="88" cy="150" r="13" fill="#FFFFFF"/>
+    <circle cx="152" cy="150" r="13" fill="#FFFFFF"/>
+    <circle cx="120" cy="88" r="17" fill="#FFFFFF"/>
+    <circle cx="120" cy="88" r="7" fill="#2D5FD0"/>
+  </g>
+  <text x="240" y="405" text-anchor="middle"
+        font-family="Helvetica Neue, Helvetica, Arial, sans-serif"
+        font-size="112" font-weight="800" letter-spacing="0" fill="#16202E">kiac</text>
+</svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -9790,6 +9790,12 @@ landscape:
             second_path:
               - "Platform / Certified Kubernetes - AI Platform"
           - item:
+            name: kiac
+            description: Local multi-node Kubernetes on Apple silicon using apple/container, with every node running in its own lightweight virtual machine.
+            homepage_url: https://saiyam1814.github.io/kiac/
+            repo_url: https://github.com/saiyam1814/kiac
+            logo: kiac.svg
+          - item:
             name: kind
             description: kind creates local multi-node Kubernetes clusters using Docker container nodes.
             homepage_url: https://github.com/kubernetes-sigs/kind


### PR DESCRIPTION
### Pre-submission checklist:

- [x] The `repo_url` points to kiac's single, fully open-source repository.
- [x] The project has at least 300 GitHub stars (313 at submission).
- [x] The single best existing category is `Platform / Certified Kubernetes - Installer`, alongside the closest comparable local installer, kind.
- [x] The entry follows the new-entry guidelines and is in alphabetical order.
- [x] The stacked SVG is included in `hosted_logos` and referenced by `logo`.
- [x] The transparent logo clearly includes the project name.
- [x] The project name and logo text both use `kiac`.
- [x] No Crunchbase URL is included because kiac is an independent open-source project, not a company-backed product.

### About kiac

kiac creates local multi-node Kubernetes clusters on Apple silicon using Apple's `container` framework. Each Kubernetes node runs in its own lightweight virtual machine.

Project: https://github.com/saiyam1814/kiac  
Homepage: https://saiyam1814.github.io/kiac/

### Validation

- Validated with the same `ghcr.io/cncf/landscape2` image used by `cncf/landscape2-validate-action@v2`
- Rendered the SVG at full and Landscape tile sizes
- Confirmed the homepage returns HTTP 200 and the repository is public and MIT licensed
