### PR TITLE
Remove Jetstack organization and member entries

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -13115,13 +13115,6 @@ landscape:
             logo: itq.svg
             crunchbase: https://www.crunchbase.com/organization/itq
           - item:
-            name: Jetstack (KCSP)
-            description: >-
-              Jetstack is an organisation focused entirely on Kubernetes. They will help you to get the most out of Kubernetes through expert professional services and open source tooling. Get in touch, and accelerate your project.
-            homepage_url: https://www.jetstack.io/
-            logo: jetstack.svg
-            crunchbase: https://www.crunchbase.com/organization/jetstack
-          - item:
             name: Kiratech S.p.A. (KCSP)
             description: Kiratech provides cloud native training and professional services for the design, implementation and operation of Kubernetes solutions.
             homepage_url: https://www.kiratech.it/
@@ -16127,12 +16120,6 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/jetify
             joined: '2024-05-01'
           - item:
-            name: Jetstack (member)
-            homepage_url: https://www.jetstack.io
-            logo: jetstack-member.svg
-            crunchbase: https://www.crunchbase.com/organization/jetstack
-            joined: '2018-01-01'
-          - item:
             name: Jozu (member)
             homepage_url: https://jozu.com
             logo: jozu.svg
@@ -18314,12 +18301,6 @@ landscape:
             logo: iherb.svg
             crunchbase: https://www.crunchbase.com/organization/iherb-com
             joined: '2019-11-01'
-          - item:
-            name: JYSK (supporter)
-            homepage_url: https://www.jysk.com/
-            logo: jysk.svg
-            crunchbase: https://www.crunchbase.com/organization/jysk-holding
-            joined: '2023-05-01'
           - item:
             name: King (supporter)
             homepage_url: https://king.com/


### PR DESCRIPTION
Removed Jetstack entries from the landscape.yml file.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
