### PR TITLE
Remove Minio GitHub repo as it is archived and no longer maintained

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -3025,7 +3025,6 @@ landscape:
           - item:
             name: MinIO
             homepage_url: https://min.io/
-            repo_url: https://github.com/minio/minio
             logo: min-io.svg
             crunchbase: https://www.crunchbase.com/organization/minio-inc
           - item:


### PR DESCRIPTION
Minio open source project is no longer maintained, the github repo is archived so remove. I believe this will then update and mark as closed source correctly.