### PR TITLE
Remove Terracotta AI member entry

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -17589,12 +17589,6 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/terasky
             joined: '2019-07-01'
           - item:
-            name: Terracotta AI (member)
-            homepage_url: https://tryterracotta.com
-            logo: terracotta-ai.svg
-            crunchbase: https://www.crunchbase.com/organization/terracotta-ai
-            joined: '2025-05-01'
-          - item:
             name: Terramate (member)
             homepage_url: https://www.terramate.io/
             logo: terramate.svg


### PR DESCRIPTION
Removed Terracotta AI member entry from landscape.yml.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you added your SVG to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other [guidelines](https://github.com/cncf/landscape#new-entries)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
