### PR TITLE
Update Open Policy Agent (OPA) metadata

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1875,6 +1875,7 @@ landscape:
             allow_duplicate_repo: true
             second_path:
               - "Serverless / Embedded Functions"
+            description: An open source, general-purpose policy engine
             extra:
               lfx_slug: openpolicyagent
               accepted: '2018-03-29'


### PR DESCRIPTION
Automated update for Open Policy Agent (OPA) from cncf/automation