### PR TITLE
Remove duplicate project entries (#4223)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -19135,7 +19135,6 @@ landscape:
             logo: nginx.svg
             crunchbase: https://www.crunchbase.com/organization/nginx
             allow_duplicate_repo: true
-            allow_duplicate_repo: true
           - item:
             name: Redpanda (Wasm)
             homepage_url: https://redpanda.com/

--- a/landscape.yml
+++ b/landscape.yml
@@ -4891,12 +4891,6 @@ landscape:
             logo: superplane.svg
             twitter: https://x.com/superplanehq
           - item:
-            name: Upbound (member)
-            homepage_url: https://upbound.io
-            logo: upbound-member.svg
-            crunchbase: https://www.crunchbase.com/organization/upbound
-            joined: '2017-12-01'
-          - item:
             name: Volcano
             homepage_url: https://volcano.sh/
             project: incubating
@@ -19141,12 +19135,6 @@ landscape:
             logo: nginx.svg
             crunchbase: https://www.crunchbase.com/organization/nginx
             allow_duplicate_repo: true
-          - item:
-            name: OpenGauss
-            homepage_url: https://opengauss.org/en/
-            repo_url: https://github.com/opengauss-mirror/openGauss-server
-            logo: opengauss.svg
-            crunchbase: https://www.crunchbase.com/organization/huawei
             allow_duplicate_repo: true
           - item:
             name: Redpanda (Wasm)


### PR DESCRIPTION
Addresses the duplicates reported in #4223 by removing two entries that are (a) exact duplicates of an entry already present elsewhere and (b) misclassified/misplaced:

- **Upbound (member)** in *Orchestration & Management &gt; Scheduling &amp; Orchestration* - an identical member entry already exists in the Members section (including the same `joined` date, logo and CrunchBase). A member organization is not a project; the canonical entry is untouched.
- **OpenGauss** in the *Embedded Functions* subcategory - an identical entry already exists under *App Definition and Development &gt; Database*. OpenGauss is a database server, not an embedded function/Wasm tool, so the stray copy is removed; the canonical Database entry (and its logo reference) is untouched.

## Verification
- Both remaining canonical entries keep their logo references (opengauss.svg, upbound-member.svg) - no dangling references introduced.
- No other file touched; only `landscape.yml` changed (12 lines deleted).

Note: `TruLens`/`Trulens` also appears twice (same repo, different description styles) but both placements look intentional and one carries `unnamed_organization: true` - left for maintainers to decide; happy to clean that up too if wanted.