### PR TITLE
Update Apicurio Registry description and summary

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -6826,7 +6826,8 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/apache
           - item:
             name: Apicurio Registry
-            description: 'Apicurio Registry is a runtime server system that stores a specific set of artifacts as files. '
+            description: >-
+              Apicurio Registry is an open-source registry for API and schema artifacts (OpenAPI, AsyncAPI, Avro, Protobuf, JSON Schema, GraphQL and more) and AI agent artifacts (A2A Agent Cards, MCP tool definitions, prompt templates, model schemas), with immutable versioning, validity and compatibility rules, role-based access control, and standards-based discovery through AI Catalog and ARD well-known endpoints.
             homepage_url: https://www.apicur.io
             project: sandbox
             repo_url: https://github.com/Apicurio/apicurio-registry
@@ -6839,6 +6840,10 @@ landscape:
               accepted: '2026-03-12'
               dev_stats_url: https://apicurioregistry.devstats.cncf.io/
               clomonitor_name: apicurio-registry
+              summary_personas: Platform Engineers, API Developers, Data Engineers, Developers
+              summary_tags: API, Schema Registry, Kafka, AI, Agentic AI, MCP, A2A
+              summary_use_case: >-
+                Apicurio Registry gives teams one governed source of truth for API contracts, event schemas and AI agent definitions: publish, version and validate artifacts, enforce compatibility rules, and expose them to serializers, gateways, IDEs and agent catalogs through standard discovery endpoints.
           - item:
             name: ArkFlow
             description: >-


### PR DESCRIPTION
Updates the **Apicurio Registry** entry (CNCF Sandbox, accepted 2026-03-12) under *App Definition and Development / Streaming & Messaging*.

**Why**

The current description — *"a runtime server system that stores a specific set of artifacts as files"* — predates the project's Sandbox acceptance and no longer describes what it does. It omits the artifact families it governs (API/schema formats) and the AI-agent registry capabilities that have shipped (A2A Agent Cards, MCP tool definitions, AI Catalog / ARD discovery endpoints).

**What**

- Replace `description` with an accurate summary of the artifact types and governance features.
- Add the optional `extra.summary_personas`, `extra.summary_tags` and `extra.summary_use_case` fields, following the format used by neighbouring entries.

No logo, URL, category or project-status changes. Only shipped functionality is named.

Submitted by a project maintainer (https://github.com/Apicurio/apicurio-registry).