### PR TITLE
Update Microcks artwork URL

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -7849,7 +7849,7 @@ landscape:
               accepted: '2023-06-22'
               incubating: '2026-05-03'
               dev_stats_url: https://microcks.devstats.cncf.io/
-              artwork_url: https://github.com/cncf/artwork/blob/master/examples/sandbox_l-r.md#microcks-logos
+              artwork_url: https://github.com/cncf/artwork/blob/main/examples/incubating.md#microcks-logos
               blog_url: https://microcks.io/blog/
               mailing_list_url: https://github.com/orgs/microcks/discussions
               slack_url: https://cloud-native.slack.com/messages/microcks


### PR DESCRIPTION
## Description

Update the Microcks artwork URL to point to its current CNCF incubating project location.

## Validation

- [x] Confirmed the new URL resolves successfully
- [x] Confirmed the page contains the `Microcks Logos` section
- [x] Confirmed `landscape.yml` parses successfully
- [x] Ran `git diff --check`